### PR TITLE
Add a link to 2.1.2 commit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ _No unreleased changes_
 ### Changed
 - Fabulous.MauiControls has moved from the Fabulous repository to its own repository: [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.1...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.2...HEAD
+[2.1.2]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/v2.1.1


### PR DESCRIPTION
@edgarfgp When adding a new version to the changelog, you also need to update the links at the bottom to a compare page between previous version and new version