### PR TITLE
Ensure templates use correct version of Fabulous and Fabulous.MauiControls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 
 env:
-  VERSION: 2.1.1
+  VERSION: 2.1.2
   CONFIG: Release
   SLN_FILE: Fabulous.MauiControls.NoSamples.sln
   TEMPLATE_PROJ: templates/Fabulous.MauiControls.Templates.proj
@@ -37,7 +37,7 @@ jobs:
       run: dotnet test ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-build
     - name: Pack
       run: |
-        find templates -type f -name template.json | xargs sed -i bak "s/FABULOUS_PKG_VERSION/${NIGHTLY_VERSION}/g"
+        find templates -type f -name template.json | xargs sed -i bak "s/PKG_VERSION/${NIGHTLY_VERSION}/g"
         dotnet pack ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-build --output nupkgs
         dotnet pack ${TEMPLATE_PROJ} -p:Version=${NIGHTLY_VERSION} -p:IsNightlyBuild=true -c ${CONFIG} --output nupkgs
     - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       run: dotnet test ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-build
     - name: Pack
       run: |
-        find templates -type f -name template.json | xargs sed -i bak "s/FABULOUS_PKG_VERSION/${RELEASE_VERSION}/g"
+        find templates -type f -name template.json | xargs sed -i bak "s/PKG_VERSION/${RELEASE_VERSION}/g"
         dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="${{ steps.changelog_reader.outputs.changes }}" -c ${CONFIG} --no-build --output nupkgs
         dotnet pack ${TEMPLATE_PROJ} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --output nupkgs
     - name: Upload artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [2.1.3] - 2023-01-14
+
+### Changed
+- Apply fix to templates to ensure correct version of Fabulous and Fabulous.MauiControls (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/4) 
+
 ## [2.1.2] - 2023-01-09
 
 ### Changed
-* Remove generic types from WidgetItems and GroupedWidgetItems by @TimLariviere in https://github.com/fabulous-dev/Fabulous.MauiControls/pull/2
+- Remove generic types from WidgetItems and GroupedWidgetItems (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/2)
 
 ## [2.1.1] - 2023-01-05
 
 ### Changed
 - Fabulous.MauiControls has moved from the Fabulous repository to its own repository: [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.2...HEAD
+[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.3...HEAD
+[2.1.2]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.2...2.1.3
 [2.1.2]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/2.1.1...2.1.2
-[2.1.1]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/v2.1.1
+[2.1.1]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/2.1.1

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="2.1.0" />
+    <PackageVersion Include="Fabulous" Version="2.1.1" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -150,7 +150,7 @@
       This version will be used as the lower bound in the NuGet package
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" PrivateAssets="All" />
-    <PackageReference Include="Fabulous" />
+    <PackageReference Include="Fabulous" VersionOverride="[2.1.0, 2.2.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/templates/Fabulous.MauiControls.Templates.proj
+++ b/templates/Fabulous.MauiControls.Templates.proj
@@ -18,6 +18,7 @@ content/*/.ionide/**/*;
 content/*/.cache/**/*;
 content/*/**/obj/**/*;
 content/*/**/bin/**/*;
+content/**/.template.config/template.jsonbak;
     </ExcludeFromPackage>
   </PropertyGroup>
   <PropertyGroup Condition=" $(IsNightlyBuild) != 'true' ">

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -42,11 +42,11 @@
       "datatype": "string",
       "defaultValue": "com.companyname"
     },
-    "FabulousPkgsVersion": {
+    "FabulousXFPkgVersion": {
       "type": "parameter",
       "dataType": "string",
-      "replaces": "FabulousPkgsVersion",
-      "defaultValue": "FABULOUS_PKG_VERSION"
+      "replaces": "FabulousXFPkgVersion",
+      "defaultValue": "PKG_VERSION"
     },
     "FSharpCorePkgVersion": {
       "type": "parameter",

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -98,7 +98,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fabulous.MauiControls" Version="FabulousPkgsVersion" />
+    <PackageReference Include="Fabulous.MauiControls" Version="FabulousXFPkgVersion" />
     <PackageReference Include="FSharp.Core" Version="FSharpCorePkgVersion" />
   </ItemGroup>
 


### PR DESCRIPTION
Following an issue found in Fabulous.XamarinForms (https://github.com/fabulous-dev/Fabulous.XamarinForms/issues/5), apply the same fix to Fabulous.MauiControls