### PR TITLE
Stop enumerating the disk if MonoAndroidAssetsPrefix is unset

### DIFF
--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'android'">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
-    <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
-    <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidResource Include="$(AndroidProjectFolder)Resources/*/*" />
+    <AndroidResource Remove="$(AndroidProjectFolder)Resources/raw/.*" />
+    <AndroidResource Update="$(AndroidProjectFolder)Resources/raw/*" />
+    <AndroidAsset Include="$(AndroidProjectFolder)Assets/**/*" Exclude="$(AndroidProjectFolder)Assets/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />

--- a/samples/HelloWorld/HelloWorld.fsproj
+++ b/samples/HelloWorld/HelloWorld.fsproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'android'">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
-    <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
-    <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidResource Include="$(AndroidProjectFolder)Resources/*/*" />
+    <AndroidResource Remove="$(AndroidProjectFolder)Resources/raw/.*" />
+    <AndroidResource Update="$(AndroidProjectFolder)Resources/raw/*" />
+    <AndroidAsset Include="$(AndroidProjectFolder)Assets/**/*" Exclude="$(AndroidProjectFolder)Assets/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'android'">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
-    <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
-    <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidResource Include="$(AndroidProjectFolder)Resources/*/*" />
+    <AndroidResource Remove="$(AndroidProjectFolder)Resources/raw/.*" />
+    <AndroidResource Update="$(AndroidProjectFolder)Resources/raw/*" />
+    <AndroidAsset Include="$(AndroidProjectFolder)Assets/**/*" Exclude="$(AndroidProjectFolder)Assets/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'android'">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
-    <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
-    <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidResource Include="$(AndroidProjectFolder)Resources/*/*" />
+    <AndroidResource Remove="$(AndroidProjectFolder)Resources/raw/.*" />
+    <AndroidResource Update="$(AndroidProjectFolder)Resources/raw/*" />
+    <AndroidAsset Include="$(AndroidProjectFolder)Assets/**/*" Exclude="$(AndroidProjectFolder)Assets/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -60,7 +60,7 @@
     <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
     <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
     <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidAsset Condition="$(MonoAndroidAssetsPrefix) != ''" Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -57,10 +57,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'android'">
-    <AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*" />
-    <AndroidResource Remove="$(MonoAndroidResourcePrefix)/raw/.*" />
-    <AndroidResource Update="$(MonoAndroidResourcePrefix)/raw/*" />
-    <AndroidAsset Condition="$(MonoAndroidAssetsPrefix) != ''" Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+    <AndroidResource Include="$(AndroidProjectFolder)Resources/*/*" />
+    <AndroidResource Remove="$(AndroidProjectFolder)Resources/raw/.*" />
+    <AndroidResource Update="$(AndroidProjectFolder)Resources/raw/*" />
+    <AndroidAsset Include="$(AndroidProjectFolder)Assets/**/*" Exclude="$(AndroidProjectFolder)Assets/**/.*/**" />
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />


### PR DESCRIPTION
If you don't have `MonoAndroidAssetsPrefix` set for whatever reason, any attempt to interact with this project will currently result in an enumeration of your entire disk via the glob `/**/*`.