### PR TITLE
Make sure Info.plist is not ignored during build

### DIFF
--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>

--- a/samples/HelloWorld/HelloWorld.fsproj
+++ b/samples/HelloWorld/HelloWorld.fsproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -69,13 +69,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
-    <None Include="$(iOSProjectFolder)Info.plist" />
+    <None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(iOSProjectFolder)AppDelegate.fs" />
     <Compile Include="$(iOSProjectFolder)Program.fs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'maccatalyst'">
-    <None Include="$(MacCatalystProjectFolder)Info.plist" />
+    <None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
     <Compile Include="$(MacCatalystProjectFolder)AppDelegate.fs" />
     <Compile Include="$(MacCatalystProjectFolder)Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
Closes #11 

Despite including the `Info.plist` file in the project, it was ignored during build and resulted in any settings inside to not be applied.
The most visible effect is the default app from the template was running in compatibility mode on iPad, despite iPad being targeted in the Info.plist.

This is because `net7.0-ios` expects the `Info.plist` file to be located at the root of the project. But Maui puts it in the `Platform\iOS` folder. To support this, we were missing the `LogicalName` attribute on the Info.plist. C# Maui does it implicitly but we need to do it explicitly with F#.

<img alt="App running on iPad fullscreen" src="https://user-images.githubusercontent.com/6429007/218059613-5c2b6942-6081-430c-9d15-11892d892951.png" height="750" />
