### PR TITLE
FormattedLabel Sample

### DIFF
--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Samples\Border.fs" />
     <Compile Include="Samples\Shapes.fs" />
     <Compile Include="Samples\Shadow.fs" />
+    <Compile Include="Samples\FormattedLabel.fs" />
     <Compile Include="Samples\ImageButton.fs" />
     <Compile Include="Samples\Label.fs" />
     <Compile Include="Samples\ThemeAware.fs" />

--- a/samples/Gallery/Samples.fs
+++ b/samples/Gallery/Samples.fs
@@ -10,4 +10,5 @@ module RegisteredSamples =
           ThemeAware.sample
           Border.sample
           Shadow.sample
-          Shapes.sample ]
+          Shapes.sample
+          FormattedLabel.sample ]

--- a/samples/Gallery/Samples/FormattedLabel.fs
+++ b/samples/Gallery/Samples/FormattedLabel.fs
@@ -1,0 +1,55 @@
+namespace Gallery.Samples
+
+open Gallery
+open Fabulous.Maui
+open Microsoft.Maui
+open Microsoft.Maui.Controls
+open Microsoft.Maui.Graphics
+open type Fabulous.Maui.View
+
+module FormattedLabel =
+    type Model = Id
+
+    type Msg =
+        | TapCommand
+        | OpenUrl of string
+
+    let init () = Id
+
+    let update msg model =
+        match msg with
+        | TapCommand -> model
+        | OpenUrl s -> model
+
+    let view model =
+        VStack(spacing = 15.) {
+            (FormattedLabel() {
+                Span("Red Bold, ").textColor(Colors.Red).font(attributes = FontAttributes.Bold)
+
+                Span("default, ").font(size = 14.).gestureRecognizers() { TapGestureRecognizer(TapCommand) }
+
+                Span("italic small.").font(attributes = FontAttributes.Italic, size = 12.)
+
+            })
+                .lineBreakMode(LineBreakMode.WordWrap)
+
+            FormattedLabel() {
+                Span("Alternatively, click ")
+
+                Span("here")
+                    .textColor(Colors.Blue)
+                    .textDecorations(TextDecorations.Underline)
+                    .gestureRecognizers() {
+                    TapGestureRecognizer(OpenUrl "https://learn.microsoft.com/dotnet/maui/")
+                }
+
+                Span(" to view .NET MAUI documentation.")
+            }
+        }
+
+    let sampleProgram = Helper.createProgram init update view
+
+    let sample =
+        { Name = "FormattedLabel"
+          Description = "Control the appearance of a label with formatted text"
+          Program = sampleProgram }


### PR DESCRIPTION
This PR adds a FormattedLabel sample to the GalleryApp.

Note: the gestures don't work on Label Spans  https://github.com/dotnet/maui/issues/4734

Workaround: to use the `Label` gestures instead.

![Simulator Screen Shot - iPhone 14 - 2023-03-25 at 12 57 51](https://user-images.githubusercontent.com/31915729/227716061-403913dd-8ebe-40bf-a4f1-f7eb2ce7b908.png)

