### PR TITLE
Type-safe events

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="2.3.1" />
+    <PackageVersion Include="Fabulous" Version="2.4.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />

--- a/src/Fabulous.MauiControls/Attributes.fs
+++ b/src/Fabulous.MauiControls/Attributes.fs
@@ -10,10 +10,12 @@ open System
 [<Struct>]
 type ValueEventData<'data, 'eventArgs> =
     { Value: 'data
-      Event: 'eventArgs -> obj }
+      Event: 'eventArgs -> MsgValue }
 
 module ValueEventData =
-    let create (value: 'data) (event: 'eventArgs -> obj) = { Value = value; Event = event }
+    let create (value: 'data) (event: 'eventArgs -> 'msg) =
+        { Value = value
+          Event = event >> box >> MsgValue }
 
 /// Maui.Controls specific attributes that can be encoded as 8 bytes
 module SmallScalars =

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -150,7 +150,7 @@
       This version will be used as the lower bound in the NuGet package
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" PrivateAssets="All" />
-    <PackageReference Include="Fabulous" VersionOverride="[2.3.0, 2.4.0)" />
+    <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/Views/Application.fs
+++ b/src/Fabulous.MauiControls/Views/Application.fs
@@ -127,21 +127,21 @@ type ApplicationModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onResume(this: WidgetBuilder<'msg, #IFabApplication>, msg: 'msg) =
-        this.AddScalar(Application.Resume.WithValue(msg))
+        this.AddScalar(Application.Resume.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the Start event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onStart(this: WidgetBuilder<'msg, #IFabApplication>, msg: 'msg) =
-        this.AddScalar(Application.Start.WithValue(msg))
+        this.AddScalar(Application.Start.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the Sleep event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onSleep(this: WidgetBuilder<'msg, #IFabApplication>, msg: 'msg) =
-        this.AddScalar(Application.Sleep.WithValue(msg))
+        this.AddScalar(Application.Sleep.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the RequestedThemeChanged event</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Application.fs
+++ b/src/Fabulous.MauiControls/Views/Application.fs
@@ -99,28 +99,28 @@ type ApplicationModifiers =
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onModalPopped(this: WidgetBuilder<'msg, #IFabApplication>, fn: ModalPoppedEventArgs -> 'msg) =
-        this.AddScalar(Application.ModalPopped.WithValue(fn >> box))
+        this.AddScalar(Application.ModalPopped.WithValue(fn))
 
     /// <summary>Listen for the ModalPopping event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onModalPopping(this: WidgetBuilder<'msg, #IFabApplication>, fn: ModalPoppingEventArgs -> 'msg) =
-        this.AddScalar(Application.ModalPopping.WithValue(fn >> box))
+        this.AddScalar(Application.ModalPopping.WithValue(fn))
 
     /// <summary>Listen for the ModalPushed event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onModalPushed(this: WidgetBuilder<'msg, #IFabApplication>, fn: ModalPushedEventArgs -> 'msg) =
-        this.AddScalar(Application.ModalPushed.WithValue(fn >> box))
+        this.AddScalar(Application.ModalPushed.WithValue(fn))
 
     /// <summary>Listen for the ModalPushing event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onModalPushing(this: WidgetBuilder<'msg, #IFabApplication>, fn: ModalPushingEventArgs -> 'msg) =
-        this.AddScalar(Application.ModalPushing.WithValue(fn >> box))
+        this.AddScalar(Application.ModalPushing.WithValue(fn))
 
     /// <summary>Listen for the Resume event</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
@@ -70,7 +70,7 @@ module EntryCellBuilders =
             WidgetBuilder<'msg, IFabEntryCell>(
                 EntryCell.WidgetKey,
                 EntryCell.Label.WithValue(label),
-                EntryCell.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
+                EntryCell.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged))
             )
 
 [<Extension>]
@@ -101,7 +101,7 @@ type EntryCellModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onCompleted(this: WidgetBuilder<'msg, #IFabEntryCell>, msg: 'msg) =
-        this.AddScalar(EntryCell.OnCompleted.WithValue(msg))
+        this.AddScalar(EntryCell.OnCompleted.WithValue(MsgValue(msg)))
 
     /// <summary>Set the placeholder text</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
@@ -70,7 +70,7 @@ module EntryCellBuilders =
             WidgetBuilder<'msg, IFabEntryCell>(
                 EntryCell.WidgetKey,
                 EntryCell.Label.WithValue(label),
-                EntryCell.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged))
+                EntryCell.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
@@ -29,7 +29,7 @@ module SwitchCellBuilders =
         static member inline SwitchCell<'msg>(text: string, value: bool, onChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabSwitchCell>(
                 SwitchCell.WidgetKey,
-                SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun _ -> onChanged)),
+                SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun (args: ToggledEventArgs) -> onChanged args.Value)),
                 SwitchCell.Text.WithValue(text)
             )
 

--- a/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
@@ -29,7 +29,7 @@ module SwitchCellBuilders =
         static member inline SwitchCell<'msg>(text: string, value: bool, onChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabSwitchCell>(
                 SwitchCell.WidgetKey,
-                SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun args -> onChanged args.Value |> box)),
+                SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun _ -> onChanged)),
                 SwitchCell.Text.WithValue(text)
             )
 

--- a/src/Fabulous.MauiControls/Views/Cells/_Cell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/_Cell.fs
@@ -51,18 +51,18 @@ type CellModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onAppearing(this: WidgetBuilder<'msg, #IFabCell>, msg: 'msg) =
-        this.AddScalar(Cell.Appearing.WithValue(msg))
+        this.AddScalar(Cell.Appearing.WithValue(MsgValue(msg)))
 
     /// <summary>Listen to the Disappearing event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onDisappearing(this: WidgetBuilder<'msg, #IFabCell>, msg: 'msg) =
-        this.AddScalar(Cell.Disappearing.WithValue(msg))
+        this.AddScalar(Cell.Disappearing.WithValue(MsgValue(msg)))
 
     /// <summary>Listen to the Tapped event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onTapped(this: WidgetBuilder<'msg, #IFabCell>, msg: 'msg) =
-        this.AddScalar(Cell.Tapped.WithValue(msg))
+        this.AddScalar(Cell.Tapped.WithValue(MsgValue(msg)))

--- a/src/Fabulous.MauiControls/Views/Collections/ListView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/ListView.fs
@@ -188,7 +188,7 @@ type ListViewModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onRefreshing(this: WidgetBuilder<'msg, #IFabListView>, msg: 'msg) =
-        this.AddScalar(ListView.Refreshing.WithValue(msg))
+        this.AddScalar(ListView.Refreshing.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the Scrolled event</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Collections/_ItemsView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/_ItemsView.fs
@@ -93,7 +93,7 @@ type ItemsViewModifiers =
     static member inline remainingItemsThreshold(this: WidgetBuilder<'msg, #IFabItemsView>, value: int, onThresholdReached: 'msg) =
         this
             .AddScalar(ItemsView.RemainingItemsThreshold.WithValue(value))
-            .AddScalar(ItemsView.RemainingItemsThresholdReached.WithValue(onThresholdReached))
+            .AddScalar(ItemsView.RemainingItemsThresholdReached.WithValue(MsgValue(onThresholdReached)))
 
     /// <summary>Set the visibility of the vertical scroll bar</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Button.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Button.fs
@@ -70,7 +70,7 @@ module ButtonBuilders =
         /// <param name="text">The button on the tex</param>
         /// <param name="onClicked">Message to dispatch</param>
         static member inline Button<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IFabButton>(Button.WidgetKey, Button.Text.WithValue(text), Button.Clicked.WithValue(onClicked))
+            WidgetBuilder<'msg, IFabButton>(Button.WidgetKey, Button.Text.WithValue(text), Button.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]
 type ButtonModifiers =
@@ -170,14 +170,14 @@ type ButtonModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onPressed(this: WidgetBuilder<'msg, #IFabButton>, msg: 'msg) =
-        this.AddScalar(Button.Pressed.WithValue(msg))
+        this.AddScalar(Button.Pressed.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the Released event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onReleased(this: WidgetBuilder<'msg, #IFabButton>, msg: 'msg) =
-        this.AddScalar(Button.Released.WithValue(msg))
+        this.AddScalar(Button.Released.WithValue(MsgValue(msg)))
 
     /// <summary>Set the padding inside the button</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
@@ -26,7 +26,7 @@ module CheckBoxBuilders =
         static member inline CheckBox<'msg>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
-                CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onCheckedChanged args.Value |> box))
+                CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onCheckedChanged))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
@@ -26,7 +26,7 @@ module CheckBoxBuilders =
         static member inline CheckBox<'msg>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
-                CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onCheckedChanged))
+                CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onCheckedChanged args.Value))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -109,7 +109,9 @@ module DatePickerBuilders =
         static member inline DatePicker<'msg>(min: DateTime, max: DateTime, date: DateTime, onDateSelected: DateTime -> 'msg) =
             WidgetBuilder<'msg, IFabDatePicker>(
                 DatePicker.WidgetKey,
-                DatePicker.DateWithEvent.WithValue(ValueEventData.create (struct (min, max, date)) (fun _ -> onDateSelected))
+                DatePicker.DateWithEvent.WithValue(
+                    ValueEventData.create (struct (min, max, date)) (fun (args: DateChangedEventArgs) -> onDateSelected args.NewDate)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -109,7 +109,7 @@ module DatePickerBuilders =
         static member inline DatePicker<'msg>(min: DateTime, max: DateTime, date: DateTime, onDateSelected: DateTime -> 'msg) =
             WidgetBuilder<'msg, IFabDatePicker>(
                 DatePicker.WidgetKey,
-                DatePicker.DateWithEvent.WithValue(ValueEventData.create (struct (min, max, date)) (fun args -> onDateSelected args.NewDate |> box))
+                DatePicker.DateWithEvent.WithValue(ValueEventData.create (struct (min, max, date)) (fun _ -> onDateSelected))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Editor.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Editor.fs
@@ -49,10 +49,7 @@ module EditorBuilders =
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
         static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
-            WidgetBuilder<'msg, IFabEditor>(
-                Editor.WidgetKey,
-                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
-            )
+            WidgetBuilder<'msg, IFabEditor>(Editor.WidgetKey, InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)))
 
 [<Extension>]
 type EditorModifiers =
@@ -125,7 +122,7 @@ type EditorModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onCompleted(this: WidgetBuilder<'msg, #IFabEditor>, msg: 'msg) =
-        this.AddScalar(Editor.Completed.WithValue(msg))
+        this.AddScalar(Editor.Completed.WithValue(MsgValue(msg)))
 
     /// <summary>Set the selection length</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Editor.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Editor.fs
@@ -49,7 +49,10 @@ module EditorBuilders =
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
         static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
-            WidgetBuilder<'msg, IFabEditor>(Editor.WidgetKey, InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)))
+            WidgetBuilder<'msg, IFabEditor>(
+                Editor.WidgetKey,
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue))
+            )
 
 [<Extension>]
 type EditorModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -67,10 +67,7 @@ module EntryBuilders =
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
         static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
-            WidgetBuilder<'msg, IFabEntry>(
-                Entry.WidgetKey,
-                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box))
-            )
+            WidgetBuilder<'msg, IFabEntry>(Entry.WidgetKey, InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)))
 
 [<Extension>]
 type EntryModifiers =
@@ -150,7 +147,7 @@ type EntryModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onCompleted(this: WidgetBuilder<'msg, #IFabEntry>, msg: 'msg) =
-        this.AddScalar(Entry.Completed.WithValue(msg))
+        this.AddScalar(Entry.Completed.WithValue(MsgValue(msg)))
 
     /// <summary>Set the return type of the keyboard</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -67,7 +67,10 @@ module EntryBuilders =
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
         static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
-            WidgetBuilder<'msg, IFabEntry>(Entry.WidgetKey, InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)))
+            WidgetBuilder<'msg, IFabEntry>(
+                Entry.WidgetKey,
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue))
+            )
 
 [<Extension>]
 type EntryModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/GraphicsView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/GraphicsView.fs
@@ -52,7 +52,7 @@ type GraphicsViewModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onCancelInteraction(this: WidgetBuilder<'msg, #IGraphicsView>, msg: 'msg) =
-        this.AddScalar(GraphicsView.CancelInteraction.WithValue(msg))
+        this.AddScalar(GraphicsView.CancelInteraction.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the DragInteraction event, with TouchEventArgs, which is raised when the GraphicsView is dragged</summary>
     /// <param name="this">Current widget</param>
@@ -66,7 +66,7 @@ type GraphicsViewModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onEndHoverInteraction(this: WidgetBuilder<'msg, #IGraphicsView>, msg: 'msg) =
-        this.AddScalar(GraphicsView.EndHoverInteraction.WithValue(msg))
+        this.AddScalar(GraphicsView.EndHoverInteraction.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the EndInteraction event, with TouchEventArgs, which is raised when the press that raised the StartInteraction event is released</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
@@ -51,7 +51,11 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         static member inline ImageButton<'msg>(source: ImageSource, onClicked: 'msg) =
-            WidgetBuilder<'msg, IFabImageButton>(ImageButton.WidgetKey, ImageButton.Clicked.WithValue(onClicked), ImageButton.Source.WithValue(source))
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(source)
+            )
 
         /// <summary>Create an ImageButton with an image source and an aspect and listen for the Click event</summary>
         /// <param name="source">The image source</param>
@@ -60,7 +64,7 @@ module ImageButtonBuilders =
         static member inline ImageButton<'msg>(source: ImageSource, onClicked: 'msg, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
-                ImageButton.Clicked.WithValue(onClicked),
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
                 ImageButton.Source.WithValue(source),
                 ImageButton.Aspect.WithValue(aspect)
             )
@@ -153,14 +157,14 @@ type ImageButtonModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onPressed(this: WidgetBuilder<'msg, #IFabImageButton>, msg: 'msg) =
-        this.AddScalar(ImageButton.Pressed.WithValue(msg))
+        this.AddScalar(ImageButton.Pressed.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the Released event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onReleased(this: WidgetBuilder<'msg, #IFabImageButton>, msg: 'msg) =
-        this.AddScalar(ImageButton.Released.WithValue(msg))
+        this.AddScalar(ImageButton.Released.WithValue(MsgValue(msg)))
 
     /// <summary>Set the padding inside the button</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Picker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Picker.fs
@@ -104,7 +104,7 @@ module PickerBuilders =
             WidgetBuilder<'msg, IFabPicker>(
                 Picker.WidgetKey,
                 Picker.ItemsSource.WithValue(Array.ofList items),
-                Picker.SelectedIndexWithEvent.WithValue(ValueEventData.create selectedIndex (fun args -> onSelectedIndexChanged args.CurrentPosition |> box))
+                Picker.SelectedIndexWithEvent.WithValue(ValueEventData.create selectedIndex (fun _ -> onSelectedIndexChanged))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Picker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Picker.fs
@@ -104,7 +104,9 @@ module PickerBuilders =
             WidgetBuilder<'msg, IFabPicker>(
                 Picker.WidgetKey,
                 Picker.ItemsSource.WithValue(Array.ofList items),
-                Picker.SelectedIndexWithEvent.WithValue(ValueEventData.create selectedIndex (fun _ -> onSelectedIndexChanged))
+                Picker.SelectedIndexWithEvent.WithValue(
+                    ValueEventData.create selectedIndex (fun (args: PositionChangedEventArgs) -> onSelectedIndexChanged args.CurrentPosition)
+                )
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
@@ -64,7 +64,7 @@ module RadioButtonBuilders =
         static member inline RadioButton<'msg>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
-                RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onChecked args.Value |> box)),
+                RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onChecked)),
                 RadioButton.ContentString.WithValue(content)
             )
 
@@ -76,7 +76,7 @@ module RadioButtonBuilders =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun args -> onChecked args.Value |> box))),
+                    StackList.one(RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onChecked))),
                     ValueSome [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
@@ -64,7 +64,7 @@ module RadioButtonBuilders =
         static member inline RadioButton<'msg>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
-                RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onChecked)),
+                RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onChecked args.Value)),
                 RadioButton.ContentString.WithValue(content)
             )
 
@@ -76,7 +76,9 @@ module RadioButtonBuilders =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun _ -> onChecked))),
+                    StackList.one(
+                        RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onChecked args.Value))
+                    ),
                     ValueSome [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
@@ -53,8 +53,8 @@ module SearchBarBuilders =
         static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
             WidgetBuilder<'msg, IFabSearchBar>(
                 SearchBar.WidgetKey,
-                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun args -> onTextChanged args.NewTextValue |> box)),
-                SearchBar.SearchButtonPressed.WithValue(onSearchButtonPressed)
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)),
+                SearchBar.SearchButtonPressed.WithValue(MsgValue(onSearchButtonPressed))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
@@ -53,7 +53,7 @@ module SearchBarBuilders =
         static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
             WidgetBuilder<'msg, IFabSearchBar>(
                 SearchBar.WidgetKey,
-                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun _ -> onTextChanged)),
+                InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue)),
                 SearchBar.SearchButtonPressed.WithValue(MsgValue(onSearchButtonPressed))
             )
 

--- a/src/Fabulous.MauiControls/Views/Controls/Slider.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Slider.fs
@@ -67,7 +67,7 @@ module SliderBuilders =
             WidgetBuilder<'msg, IFabSlider>(
                 Slider.WidgetKey,
                 Slider.MinimumMaximum.WithValue(struct (min, max)),
-                Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box))
+                Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun _ -> onValueChanged))
             )
 
 [<Extension>]
@@ -77,14 +77,14 @@ type SliderModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onDragCompleted(this: WidgetBuilder<'msg, #IFabSlider>, msg: 'msg) =
-        this.AddScalar(Slider.DragCompleted.WithValue(msg))
+        this.AddScalar(Slider.DragCompleted.WithValue(MsgValue(msg)))
 
     /// <summary>Listen for the DragStarted event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onDragStarted(this: WidgetBuilder<'msg, #IFabSlider>, msg: 'msg) =
-        this.AddScalar(Slider.DragStarted.WithValue(msg))
+        this.AddScalar(Slider.DragStarted.WithValue(MsgValue(msg)))
 
     /// <summary>Set the color of the maximum track</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Slider.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Slider.fs
@@ -67,7 +67,7 @@ module SliderBuilders =
             WidgetBuilder<'msg, IFabSlider>(
                 Slider.WidgetKey,
                 Slider.MinimumMaximum.WithValue(struct (min, max)),
-                Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun _ -> onValueChanged))
+                Slider.ValueWithEvent.WithValue(ValueEventData.create value (fun (args: ValueChangedEventArgs) -> onValueChanged args.NewValue))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
@@ -49,7 +49,7 @@ module StepperBuilders =
             WidgetBuilder<'msg, IFabStepper>(
                 Stepper.WidgetKey,
                 Stepper.MinimumMaximum.WithValue(struct (min, max)),
-                Stepper.ValueWithEvent.WithValue(ValueEventData.create value (fun _ -> onValueChanged))
+                Stepper.ValueWithEvent.WithValue(ValueEventData.create value (fun (args: ValueChangedEventArgs) -> onValueChanged args.NewValue))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
@@ -49,7 +49,7 @@ module StepperBuilders =
             WidgetBuilder<'msg, IFabStepper>(
                 Stepper.WidgetKey,
                 Stepper.MinimumMaximum.WithValue(struct (min, max)),
-                Stepper.ValueWithEvent.WithValue(ValueEventData.create value (fun args -> onValueChanged args.NewValue |> box))
+                Stepper.ValueWithEvent.WithValue(ValueEventData.create value (fun _ -> onValueChanged))
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Switch.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Switch.fs
@@ -26,10 +26,7 @@ module SwitchBuilders =
         /// <param name="isToggled">The toggle state</param>
         /// <param name="onToggled">Message to dispatch</param>
         static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
-            WidgetBuilder<'msg, IFabSwitch>(
-                Switch.WidgetKey,
-                Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun args -> onToggled args.Value |> box))
-            )
+            WidgetBuilder<'msg, IFabSwitch>(Switch.WidgetKey, Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun _ -> onToggled)))
 
 [<Extension>]
 type SwitchModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/Switch.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Switch.fs
@@ -26,7 +26,10 @@ module SwitchBuilders =
         /// <param name="isToggled">The toggle state</param>
         /// <param name="onToggled">Message to dispatch</param>
         static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
-            WidgetBuilder<'msg, IFabSwitch>(Switch.WidgetKey, Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun _ -> onToggled)))
+            WidgetBuilder<'msg, IFabSwitch>(
+                Switch.WidgetKey,
+                Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun (args: ToggledEventArgs) -> onToggled args.Value))
+            )
 
 [<Extension>]
 type SwitchModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -73,10 +73,7 @@ module TimePickerBuilders =
         /// <param name="time">The selected time</param>
         /// <param name="onTimeSelected">Message to dispatch</param>
         static member inline TimePicker<'msg>(time: TimeSpan, onTimeSelected: TimeSpan -> 'msg) =
-            WidgetBuilder<'msg, IFabTimePicker>(
-                TimePicker.WidgetKey,
-                TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun args -> onTimeSelected args.NewTime |> box))
-            )
+            WidgetBuilder<'msg, IFabTimePicker>(TimePicker.WidgetKey, TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun _ -> onTimeSelected)))
 
 [<Extension>]
 type TimePickerModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -73,7 +73,10 @@ module TimePickerBuilders =
         /// <param name="time">The selected time</param>
         /// <param name="onTimeSelected">Message to dispatch</param>
         static member inline TimePicker<'msg>(time: TimeSpan, onTimeSelected: TimeSpan -> 'msg) =
-            WidgetBuilder<'msg, IFabTimePicker>(TimePicker.WidgetKey, TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun _ -> onTimeSelected)))
+            WidgetBuilder<'msg, IFabTimePicker>(
+                TimePicker.WidgetKey,
+                TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun (args: TimeSelectedEventArgs) -> onTimeSelected args.NewTime))
+            )
 
 [<Extension>]
 type TimePickerModifiers =

--- a/src/Fabulous.MauiControls/Views/Layouts/RefreshView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/RefreshView.fs
@@ -31,7 +31,7 @@ module RefreshViewBuilders =
             WidgetBuilder<'msg, IFabRefreshView>(
                 RefreshView.WidgetKey,
                 AttributesBundle(
-                    StackList.two(RefreshView.IsRefreshing.WithValue(isRefreshing), RefreshView.Refreshing.WithValue(onRefreshing)),
+                    StackList.two(RefreshView.IsRefreshing.WithValue(isRefreshing), RefreshView.Refreshing.WithValue(MsgValue(onRefreshing))),
                     ValueSome [| ContentView.Content.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
@@ -32,7 +32,7 @@ module MenuItemBuilders =
         /// <param name="text">The text</param>
         /// <param name="onClicked">The click callback</param>
         static member inline MenuItem<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IFabMenuItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(onClicked))
+            WidgetBuilder<'msg, IFabMenuItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]
 type MenuItemModifiers =

--- a/src/Fabulous.MauiControls/Views/MenuItems/ToolbarItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/ToolbarItem.fs
@@ -34,7 +34,7 @@ module ToolbarItemBuilders =
         /// <param name="text">The text</param>
         /// <param name="onClicked">The click callback</param>
         static member inline ToolbarItem<'msg>(text: string, onClicked: 'msg) =
-            WidgetBuilder<'msg, IFabToolbarItem>(ToolbarItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(onClicked))
+            WidgetBuilder<'msg, IFabToolbarItem>(ToolbarItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]
 type ToolbarItemModifiers =

--- a/src/Fabulous.MauiControls/Views/Pages/ContentPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/ContentPage.fs
@@ -52,7 +52,7 @@ type ContentPageModifiers =
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onSizeAllocated(this: WidgetBuilder<'msg, #IFabContentPage>, fn: SizeAllocatedEventArgs -> 'msg) =
-        this.AddScalar(ContentPage.SizeAllocated.WithValue(fn >> box))
+        this.AddScalar(ContentPage.SizeAllocated.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct ContentPage control instance</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/FlyoutPage.fs
@@ -74,7 +74,7 @@ type FlyoutPageModifiers =
     /// <param name="onChanged">Message to dispatch</param>
     [<Extension>]
     static member inline isPresented(this: WidgetBuilder<'msg, #IFabFlyoutPage>, value: bool, onChanged: bool -> 'msg) =
-        this.AddScalar(FlyoutPage.IsPresented.WithValue(ValueEventData.create value (fun v -> onChanged v |> box)))
+        this.AddScalar(FlyoutPage.IsPresented.WithValue(ValueEventData.create value onChanged))
 
     /// <summary>Set whether gesture is enabled to open the flyout</summary>
     /// <param name="this">Current widget</param>
@@ -88,7 +88,7 @@ type FlyoutPageModifiers =
     /// <param name="fn">Message to dispatch</param>
     [<Extension>]
     static member inline onBackButtonPressed(this: WidgetBuilder<'msg, #IFabFlyoutPage>, fn: bool -> 'msg) =
-        this.AddScalar(FlyoutPage.BackButtonPressed.WithValue(fun args -> fn args.Handled |> box))
+        this.AddScalar(FlyoutPage.BackButtonPressed.WithValue(fun args -> fn args.Handled))
 
     /// <summary>Link a ViewRef to access the direct FlyoutPage control instance</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
@@ -369,14 +369,14 @@ type NavigationPageModifiers =
     /// <remarks>Setting this modifier will prevent the default behavior of the system back button. It's up to you to update the navigation stack.</remarks>
     [<Extension>]
     static member inline onBackButtonPressed(this: WidgetBuilder<'msg, #IFabNavigationPage>, msg: 'msg) =
-        this.AddScalar(NavigationPage.BackButtonPressed.WithValue(msg))
+        this.AddScalar(NavigationPage.BackButtonPressed.WithValue(MsgValue(msg)))
 
     /// <summary>Listen to the user back navigating</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onBackNavigated(this: WidgetBuilder<'msg, #IFabNavigationPage>, msg: 'msg) =
-        this.AddScalar(NavigationPage.BackNavigated.WithValue(msg))
+        this.AddScalar(NavigationPage.BackNavigated.WithValue(MsgValue(msg)))
 
     /// <summary>Link a ViewRef to access the direct NavigationPage control instance</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Pages/_MultiPageOfPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_MultiPageOfPage.fs
@@ -21,4 +21,4 @@ type MultiPageOfPageModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onCurrentPageChanged(this: WidgetBuilder<'msg, #IFabMultiPageOfPage>, msg: 'msg) =
-        this.AddScalar(MultiPageOfPage.CurrentPageChanged.WithValue(msg))
+        this.AddScalar(MultiPageOfPage.CurrentPageChanged.WithValue(MsgValue(msg)))

--- a/src/Fabulous.MauiControls/Views/Pages/_Page.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_Page.fs
@@ -73,14 +73,14 @@ type PageModifiers =
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onAppearing(this: WidgetBuilder<'msg, #IFabPage>, msg: 'msg) =
-        this.AddScalar(Page.Appearing.WithValue(msg))
+        this.AddScalar(Page.Appearing.WithValue(MsgValue(msg)))
 
     /// <summary>Listen to the Disappearing event</summary>
     /// <param name="this">Current widget</param>
     /// <param name="msg">Message to dispatch</param>
     [<Extension>]
     static member inline onDisappearing(this: WidgetBuilder<'msg, #IFabPage>, msg: 'msg) =
-        this.AddScalar(Page.Disappearing.WithValue(msg))
+        this.AddScalar(Page.Disappearing.WithValue(MsgValue(msg)))
 
     /// <summary>Set the padding inside the widget</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/CompositeTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/CompositeTransform.fs
@@ -74,9 +74,9 @@ module CompositeTransformBuilders =
         static member inline CompositeTransform<'msg>(centerX: float, centerY: float, scaleX: float, scaleY: float, skewX: float, skewY: float) =
             WidgetBuilder<'msg, IFabCompositeTransform>(
                 CompositeTransform.WidgetKey,
-                CompositeTransform.CenterXY.WithValue((centerX, centerY)),
-                CompositeTransform.ScaleXY.WithValue((scaleX, scaleY)),
-                CompositeTransform.SkewXY.WithValue((skewX, skewY))
+                CompositeTransform.CenterXY.WithValue(struct (centerX, centerY)),
+                CompositeTransform.ScaleXY.WithValue(struct (scaleX, scaleY)),
+                CompositeTransform.SkewXY.WithValue(struct (skewX, skewY))
             )
 
 [<Extension>]
@@ -87,7 +87,7 @@ type CompositeTransformModifiers =
     /// <param name="y">The Y component of the translation</param>
     [<Extension>]
     static member inline translate(this: WidgetBuilder<'msg, #IFabCompositeTransform>, x: float, y: float) =
-        this.AddScalar(CompositeTransform.TranslateXY.WithValue((x, y)))
+        this.AddScalar(CompositeTransform.TranslateXY.WithValue(struct (x, y)))
 
     /// <summary>Set the rotation value</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/MatrixTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/MatrixTransform.fs
@@ -37,7 +37,7 @@ module MatrixTransformBuilders =
         /// <param name="offsetX">The X component of the offset</param>
         /// <param name="offsetY">The Y component of the offset</param>
         static member inline MatrixTransform<'msg>(m11: float, m12: float, m21: float, m22: float, offsetX: float, offsetY: float) =
-            WidgetBuilder<'msg, IFabMatrixTransform>(MatrixTransform.WidgetKey, MatrixTransform.Matrix.WithValue((m11, m12, m21, m22, offsetX, offsetY)))
+            WidgetBuilder<'msg, IFabMatrixTransform>(MatrixTransform.WidgetKey, MatrixTransform.Matrix.WithValue(struct (m11, m12, m21, m22, offsetX, offsetY)))
 
 [<Extension>]
 type MatrixTransformModifiers =

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/ScaleTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/ScaleTransform.fs
@@ -38,7 +38,7 @@ module ScaleTransformBuilders =
         static member inline ScaleTransform<'msg>(scaleX: float, scaleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IFabScaleTransform>(
                 ScaleTransform.WidgetKey,
-                ScaleTransform.ScaleXY.WithValue((scaleX, scaleY)),
+                ScaleTransform.ScaleXY.WithValue(struct (scaleX, scaleY)),
                 ScaleTransform.CenterX.WithValue(centerX),
                 ScaleTransform.CenterY.WithValue(centerY)
             )

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/SkewTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/SkewTransform.fs
@@ -38,7 +38,7 @@ module SkewTransformBuilders =
         static member inline SkewTransform<'msg>(angleX: float, angleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IFabSkewTransform>(
                 SkewTransform.WidgetKey,
-                SkewTransform.AnglesXY.WithValue((angleX, angleY)),
+                SkewTransform.AnglesXY.WithValue(struct (angleX, angleY)),
                 SkewTransform.CenterX.WithValue(centerX),
                 SkewTransform.CenterY.WithValue(centerY)
             )

--- a/src/Fabulous.MauiControls/Views/_VisualElement.fs
+++ b/src/Fabulous.MauiControls/Views/_VisualElement.fs
@@ -262,7 +262,7 @@ type VisualElementModifiers =
     /// <param name="onFocusChanged">Message to dispatch when the widget's focus state changes</param>
     [<Extension>]
     static member inline focus(this: WidgetBuilder<'msg, #IFabVisualElement>, value: bool, onFocusChanged: bool -> 'msg) =
-        this.AddScalar(VisualElement.FocusWithEvent.WithValue(ValueEventData.create value (fun args -> onFocusChanged args |> box)))
+        this.AddScalar(VisualElement.FocusWithEvent.WithValue(ValueEventData.create value onFocusChanged))
 
     /// <summary>Set the layout flow direction</summary>
     /// <param name="this">Current widget</param>

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -46,7 +46,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgVersion",
-      "defaultValue": "2.3.1"
+      "defaultValue": "2.4.0"
     },
     "FabulousMauiControlsPkgVersion": {
       "type": "parameter",


### PR DESCRIPTION
To help avoid crashes in mapping to events, Fabulous now uses a specialized type instead of obj to store a message for events with no args.

Also, changed ValueEventData.create and ValueEventData.createVOption to implicitly box the resulting message.

Similar to https://github.com/fabulous-dev/Fabulous.Avalonia/pull/163