### PR TITLE
Check the focus state of the target before calling focus/unfocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Fixed
+- Check the focus state of the target before calling focus/unfocus by @TimLariviere (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/43)
 
 ## [2.8.0] - 2023-08-08
 
 ### Changed
-- Remove ambiguity when declaring event attributes by using MsgValue instead of obj by @edgarfgp (#42)
+- Remove ambiguity when declaring event attributes by using MsgValue instead of obj by @edgarfgp (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/42)
 
 ## [2.7.0] - 2023-06-01
 

--- a/src/Fabulous.MauiControls/Views/_VisualElement.fs
+++ b/src/Fabulous.MauiControls/Views/_VisualElement.fs
@@ -39,10 +39,10 @@ module VisualElementUpdaters =
     let updateVisualElementFocus oldValueOpt (newValueOpt: ValueEventData<bool, bool> voption) (node: IViewNode) =
         let target = node.Target :?> VisualElement
 
-        let onEventName = $"Focus_On"
+        let onEventName = "Focus_On"
         let onEvent = target.Focused
 
-        let offEventName = $"Focus_Off"
+        let offEventName = "Focus_Off"
         let offEvent = target.Unfocused
 
         match newValueOpt with
@@ -59,7 +59,9 @@ module VisualElementUpdaters =
             // Only clear the property if a value was set before
             match oldValueOpt with
             | ValueNone -> ()
-            | ValueSome _ -> target.Unfocus()
+            | ValueSome _ ->
+                if target.IsFocused then
+                    target.Unfocus()
 
         | ValueSome curr ->
             // Clean up the old event handlers if any
@@ -72,7 +74,7 @@ module VisualElementUpdaters =
             | ValueSome handler -> offEvent.RemoveHandler(handler)
 
             // Set the new value
-            if curr.Value then
+            if curr.Value && target.IsFocused <> curr.Value then
                 target.Focus() |> ignore
             else
                 target.Unfocus()


### PR DESCRIPTION
Fixes an issue on Android where an infinite loop can occur because Maui switches focus between fields randomly.