### PR TITLE
Fix crash events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Check the focus state of the target before calling focus/unfocus by @TimLariviere (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/43)
+- Fix crash when dispatching a message after an event occurred by @TimLariviere (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/44)
 
 ## [2.8.0] - 2023-08-08
 

--- a/samples/Playground/App.fs
+++ b/samples/Playground/App.fs
@@ -1,11 +1,6 @@
 namespace Playground
 
-open Fabulous
 open Fabulous.Maui
-open Microsoft.Maui
-open Microsoft.Maui.Graphics
-open Microsoft.Maui.Accessibility
-open Microsoft.Maui.Primitives
 
 open type Fabulous.Maui.View
 

--- a/src/Fabulous.MauiControls/Attributes.fs
+++ b/src/Fabulous.MauiControls/Attributes.fs
@@ -3,7 +3,6 @@ namespace Fabulous.Maui
 open System.Runtime.CompilerServices
 open Fabulous
 open Fabulous.ScalarAttributeDefinitions
-open Fabulous.Maui
 open Microsoft.Maui.Controls
 open System
 
@@ -160,7 +159,7 @@ module Attributes =
                         // Set the new event handler
                         let handler =
                             EventHandler<'args>(fun _ args ->
-                                let r = curr.Event args
+                                let (MsgValue r) = curr.Event args
                                 Dispatcher.dispatch node r)
 
                         node.SetHandler(name, ValueSome handler)

--- a/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -59,7 +59,7 @@ module DatePicker =
                         // Set the new event handler
                         let handler =
                             EventHandler<DateChangedEventArgs>(fun _ args ->
-                                let r = curr.Event args
+                                let (MsgValue r) = curr.Event args
                                 Dispatcher.dispatch node r)
 
                         node.SetHandler(name, ValueSome handler)

--- a/src/Fabulous.MauiControls/Views/_VisualElement.fs
+++ b/src/Fabulous.MauiControls/Views/_VisualElement.fs
@@ -74,15 +74,16 @@ module VisualElementUpdaters =
             | ValueSome handler -> offEvent.RemoveHandler(handler)
 
             // Set the new value
-            if curr.Value && target.IsFocused <> curr.Value then
-                target.Focus() |> ignore
-            else
-                target.Unfocus()
+            if target.IsFocused <> curr.Value then
+                if curr.Value then
+                    target.Focus() |> ignore
+                else
+                    target.Unfocus()
 
             // Set the new event handlers
             let onHandler =
                 EventHandler<FocusEventArgs>(fun _ args ->
-                    let r = curr.Event true
+                    let (MsgValue r) = curr.Event true
                     Dispatcher.dispatch node r)
 
             node.SetHandler(onEventName, ValueSome onHandler)
@@ -90,7 +91,7 @@ module VisualElementUpdaters =
 
             let offHandler =
                 EventHandler<FocusEventArgs>(fun _ args ->
-                    let r = curr.Event false
+                    let (MsgValue r) = curr.Event false
                     Dispatcher.dispatch node r)
 
             node.SetHandler(offEventName, ValueSome offHandler)


### PR DESCRIPTION
`Entry` crashes when using `.focus(...)` modifier due to a forgotten unwrapping when dispatching the corresponding message.

This issue was fixed in the `net8.0` branch but never applied to the `main` branch.
This PR also comes with the other fixes of `net8.0` branch