### PR TITLE
Target .NET 8.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "5.2.0",
+      "version": "6.2.3",
       "commands": [
         "fantomas"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.x
-        includePreviewVersions: true
     - name: Use correct Xcode version
       run: sudo xcode-select -s ${XCODE_PATH}
     - name: Install dotnet workload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.x
+        includePreviewVersions: true
     - name: Use correct Xcode version
       run: sudo xcode-select -s ${XCODE_PATH}
     - name: Install dotnet workload
@@ -61,7 +62,6 @@ jobs:
         dotnet nuget add source $LOCAL_NUGET_PATH --name local
         dotnet new install Fabulous.MauiControls.Templates::${NIGHTLY_VERSION}
         dotnet new fabulous-mauicontrols -n TestTemplates
-        dotnet build TestTemplates -p:ManagePackageVersionsCentrally=false -f net7.0-android -t:CompileResourceDesignerForFSharp
         dotnet build TestTemplates -p:ManagePackageVersionsCentrally=false
     - name: Push
       run: dotnet nuget push "nupkgs/*.nupkg" -s https://nuget.pkg.github.com/fabulous-dev/index.json -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   TEMPLATE_PROJ: templates/Fabulous.MauiControls.Templates.proj
   TEMPLATE_PKG: nupkgs/Fabulous.MauiControls.Templates
   NUPKG_FOLDER: nupkgs
-  XCODE_PATH: /Applications/Xcode_14.3.app/Contents/Developer
+  XCODE_PATH: /Applications/Xcode_15.0.1.app/Contents/Developer
 
 jobs:
   build:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Check code formatting
       run: |
         dotnet tool restore
-        dotnet fantomas --check -r src samples templates
+        dotnet fantomas --check src samples templates
     - name: Use correct Xcode version
       run: sudo xcode-select -s ${XCODE_PATH}
     - name: Install dotnet workload

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,7 @@ on: pull_request
 env:
   SLN_FILE: Fabulous.MauiControls.NoSamples.sln
   CONFIG: Release
-  XCODE_PATH: /Applications/Xcode_14.3.app/Contents/Developer
+  XCODE_PATH: /Applications/Xcode_15.0.1.app/Contents/Developer
 
 jobs:
   pull_request:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.x
+        includePreviewVersions: true
     - name: Check code formatting
       run: |
         dotnet tool restore

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.x
-        includePreviewVersions: true
     - name: Check code formatting
       run: |
         dotnet tool restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.x
-        includePreviewVersions: true
     - name: Use correct Xcode version
       run: sudo xcode-select -s ${XCODE_PATH}
     - name: Install dotnet workload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.x
+        includePreviewVersions: true
     - name: Use correct Xcode version
       run: sudo xcode-select -s ${XCODE_PATH}
     - name: Install dotnet workload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   CONFIG: Release
   SLN_FILE: Fabulous.MauiControls.NoSamples.sln
   TEMPLATE_PROJ: templates/Fabulous.MauiControls.Templates.proj
-  XCODE_PATH: /Applications/Xcode_14.3.app/Contents/Developer
+  XCODE_PATH: /Applications/Xcode_15.0.1.app/Contents/Developer
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Added
+- Add missing `ignoreSafeArea` modifier to layout widgets (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/44)
 
 ## [2.8.1] - 2023-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes_
+
+## [8.0.0] - 2023-11-14
+
+IMPORTANT: Fabulous.MauiControls will now follow the same versioning as .NET MAUI to reflect the dependency on a specific version of .NET MAUI.  
+Essentially v2.8.1 and v8.0.0 are similar except for the required .NET version.
+
+### Changed
+- Target .NET 8.0
+
 ### Added
 - Add missing `ignoreSafeArea` modifier to layout widgets (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/44)
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,10 @@
     <PackageVersion Include="FSharp.Maui.WinUICompat" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-preview.7.8842" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.7.23375.6" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,19 +6,19 @@
 
   <ItemGroup>
     <PackageVersion Include="Fabulous" Version="2.4.0" />
-    <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
-    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23418.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageVersion Include="FsCheck.NUnit" Version="2.16.6" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23475.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageVersion Include="FSharp.Maui.WinUICompat" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.1.9171" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.1.23419.4" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.1.23419.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9511" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.2.9511" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.2.23479.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.2.23479.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.2.23479.6" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,13 +7,14 @@
   <ItemGroup>
     <PackageVersion Include="Fabulous" Version="2.4.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
-    <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
-    <PackageVersion Include="FSharp.Core" Version="7.0.0" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23371.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageVersion Include="FSharp.Maui.WinUICompat" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-preview.7.8842" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,18 +7,18 @@
   <ItemGroup>
     <PackageVersion Include="Fabulous" Version="2.4.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.6" />
-    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23475.2" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.100" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageVersion Include="FSharp.Maui.WinUICompat" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9511" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.2.9511" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.2.23479.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.2.23479.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.2.23479.6" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,18 +7,18 @@
   <ItemGroup>
     <PackageVersion Include="Fabulous" Version="2.4.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
-    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23371.8" />
+    <PackageVersion Include="FSharp.Core" Version="8.0.100-beta.23418.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageVersion Include="FSharp.Maui.WinUICompat" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-preview.7.8842" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-preview.7.8842" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-preview.7.23375.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.7.23375.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.7.23375.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-preview.7.23375.6" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="8.0.0-rc.1.9171" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.0-rc.1.9171" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
 
 </Project>

--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -93,6 +93,12 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>CounterApp</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -63,8 +63,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">

--- a/samples/CounterApp/Platforms/Android/MainApplication.fs
+++ b/samples/CounterApp/Platforms/Android/MainApplication.fs
@@ -7,6 +7,4 @@ open Microsoft.Maui
 type MainApplication(handle, ownership) =
     inherit MauiApplication(handle, ownership)
 
-    do CounterApp.Resource.UpdateIdValues()
-
     override _.CreateMauiApp() = MauiProgram.CreateMauiApp()

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework>net8.0-ios</TargetFramework>
     <OutputType>Exe</OutputType>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
@@ -71,8 +71,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -102,6 +102,12 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Fabulous" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/HelloWorld/HelloWorld.fsproj
+++ b/samples/HelloWorld/HelloWorld.fsproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>HelloWorld</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -63,8 +63,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">

--- a/samples/HelloWorld/HelloWorld.fsproj
+++ b/samples/HelloWorld/HelloWorld.fsproj
@@ -94,6 +94,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Fabulous.MauiControls\Fabulous.MauiControls.fsproj" />
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
 </Project>

--- a/samples/HelloWorld/Platforms/Android/MainApplication.fs
+++ b/samples/HelloWorld/Platforms/Android/MainApplication.fs
@@ -7,6 +7,4 @@ open Microsoft.Maui
 type MainApplication(handle, ownership) =
     inherit MauiApplication(handle, ownership)
 
-    do HelloWorld.Resource.UpdateIdValues()
-
     override _.CreateMauiApp() = MauiProgram.CreateMauiApp()

--- a/samples/Playground/Platforms/Android/MainApplication.fs
+++ b/samples/Playground/Platforms/Android/MainApplication.fs
@@ -7,6 +7,4 @@ open Microsoft.Maui
 type MainApplication(handle, ownership) =
     inherit MauiApplication(handle, ownership)
 
-    do Playground.Resource.UpdateIdValues()
-
     override _.CreateMauiApp() = MauiProgram.CreateMauiApp()

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>Playground</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -63,8 +63,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -94,6 +94,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Fabulous.MauiControls\Fabulous.MauiControls.fsproj" />
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
 </Project>

--- a/samples/TicTacToe/Platforms/Android/MainApplication.fs
+++ b/samples/TicTacToe/Platforms/Android/MainApplication.fs
@@ -7,6 +7,4 @@ open Microsoft.Maui
 type MainApplication(handle, ownership) =
     inherit MauiApplication(handle, ownership)
 
-    do TicTacToe.Resource.UpdateIdValues()
-
     override _.CreateMauiApp() = MauiProgram.CreateMauiApp()

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -93,6 +93,12 @@
 
   <ItemGroup>
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>TicTacToe</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -63,8 +63,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">

--- a/src/Fabulous.MauiControls.Tests/Fabulous.MauiControls.Tests.fsproj
+++ b/src/Fabulous.MauiControls.Tests/Fabulous.MauiControls.Tests.fsproj
@@ -14,6 +14,12 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Fabulous.MauiControls\Fabulous.MauiControls.fsproj" />

--- a/src/Fabulous.MauiControls.Tests/Fabulous.MauiControls.Tests.fsproj
+++ b/src/Fabulous.MauiControls.Tests/Fabulous.MauiControls.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UseMaui>true</UseMaui>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -151,10 +151,10 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23418.2" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23475.2" PrivateAssets="All" />
     <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-rc.1.9171" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-rc.1.9171" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-rc.2.9511" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-rc.2.9511" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -149,10 +149,10 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23371.8" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23418.2" PrivateAssets="All" />
     <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-preview.7.8842" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-preview.7.8842" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-rc.1.9171" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-rc.1.9171" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UseMaui>true</UseMaui>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -149,8 +149,10 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="FSharp.Core" VersionOverride="7.0.0" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23371.8" PrivateAssets="All" />
     <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-preview.7.8842" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-preview.7.8842" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -45,8 +45,10 @@
     <Compile Include="Views\GestureRecognizers\DragGestureRecognizer.fs" />
     <Compile Include="Views\GestureRecognizers\DropGestureRecognizer.fs" />
     <Compile Include="Views\_View.fs" />
+    <Compile Include="Views\KeyboardAccelerator.fs" />
     <Compile Include="Views\MenuItems\MenuItem.fs" />
     <Compile Include="Views\MenuItems\ToolbarItem.fs" />
+    <Compile Include="Views\MenuItems\MenuFlyoutItem.fs" />
     <Compile Include="Views\Cells\_Cell.fs" />
     <Compile Include="Views\Cells\ViewCell.fs" />
     <Compile Include="Views\Cells\TextCell.fs" />

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -151,10 +151,10 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100-beta.23475.2" PrivateAssets="All" />
+    <PackageReference Include="FSharp.Core" VersionOverride="8.0.100" PrivateAssets="All" />
     <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.0-rc.2.9511" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.0-rc.2.9511" />
+    <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.3" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/Views/KeyboardAccelerator.fs
+++ b/src/Fabulous.MauiControls/Views/KeyboardAccelerator.fs
@@ -1,0 +1,37 @@
+namespace Fabulous.Maui
+
+open Fabulous
+open Microsoft.Maui
+open Microsoft.Maui.Controls
+
+type IFabKeyboardAccelerator =
+    interface
+    end
+
+module KeyboardAccelerator =
+    let WidgetKey = Widgets.register<KeyboardAccelerator>()
+
+    let Key =
+        Attributes.defineBindableWithEquality<string> KeyboardAccelerator.KeyProperty
+
+    let Modifiers =
+        Attributes.defineBindableWithEquality<KeyboardAcceleratorModifiers> KeyboardAccelerator.ModifiersProperty
+
+[<AutoOpen>]
+module KeyboardAcceleratorBuilders =
+    type Fabulous.Maui.View with
+
+        /// <summary>Create a KeyboardAccelerator widget with a key</summary>
+        /// <param name="key">The key triggering the accelerator</param>
+        static member inline KeyboardAccelerator<'msg>(key: string) =
+            WidgetBuilder<'msg, IFabKeyboardAccelerator>(KeyboardAccelerator.WidgetKey, KeyboardAccelerator.Key.WithValue(key))
+
+        /// <summary>Create a KeyboardAccelerator widget with a key and a modifier</summary>
+        /// <param name="key">The key triggering the accelerator</param>
+        /// <param name="modifiers">The modifiers required to trigger the accelerator</param>
+        static member inline KeyboardAccelerator<'msg>(key: string, modifiers: KeyboardAcceleratorModifiers) =
+            WidgetBuilder<'msg, IFabKeyboardAccelerator>(
+                KeyboardAccelerator.WidgetKey,
+                KeyboardAccelerator.Key.WithValue(key),
+                KeyboardAccelerator.Modifiers.WithValue(modifiers)
+            )

--- a/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
@@ -13,7 +13,7 @@ module Layout =
         Attributes.defineBindableBool Layout.CascadeInputTransparentProperty
 
     let IgnoreSafeArea =
-        Attributes.defineSimpleScalarWithEquality "Layout_IgnoreSafeArea" (fun prevOpt currOpt node ->
+        Attributes.defineSmallScalar "Layout_IgnoreSafeArea" SmallScalars.Bool.decode (fun prevOpt currOpt node ->
             let target = node.Target :?> Layout
 
             match struct (prevOpt, currOpt) with

--- a/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
@@ -38,7 +38,7 @@ type LayoutModifiers =
 
     /// <summary>Set whether the layout can extend inside the safe area on iOS</summary>
     /// <param name="this">Current widget</param>
-    /// <param name="value">false, the layout can extend inside the safe area on iOS; true, the layout is constrained outside the safe area</param>
+    /// <param name="value">false, the layout is constrained outside the safe area; true, the layout can extend into the safe area</param>
     [<Extension>]
     static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IFabLayout>, value: bool) =
         this.AddScalar(Layout.IgnoreSafeArea.WithValue(value))
@@ -62,7 +62,7 @@ type LayoutExtraModifiers =
     /// <summary>Allow the layout to extend into the safe area</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IFabLayout>) = this.ignoreSafeArea(false)
+    static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IFabLayout>) = this.ignoreSafeArea(true)
 
     /// <summary>Set the padding inside the widget</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/_Layout.fs
@@ -12,6 +12,15 @@ module Layout =
     let CascadeInputTransparent =
         Attributes.defineBindableBool Layout.CascadeInputTransparentProperty
 
+    let IgnoreSafeArea =
+        Attributes.defineSimpleScalarWithEquality "Layout_IgnoreSafeArea" (fun prevOpt currOpt node ->
+            let target = node.Target :?> Layout
+
+            match struct (prevOpt, currOpt) with
+            | ValueNone, ValueNone -> ()
+            | ValueSome _, ValueNone -> target.IgnoreSafeArea <- false
+            | _, ValueSome value -> target.IgnoreSafeArea <- value)
+
     let IsClippedToBounds =
         Attributes.defineBindableBool Layout.IsClippedToBoundsProperty
 
@@ -26,6 +35,13 @@ type LayoutModifiers =
     [<Extension>]
     static member inline cascadeInputTransparent(this: WidgetBuilder<'msg, #IFabLayout>, value: bool) =
         this.AddScalar(Layout.CascadeInputTransparent.WithValue(value))
+
+    /// <summary>Set whether the layout can extend inside the safe area on iOS</summary>
+    /// <param name="this">Current widget</param>
+    /// <param name="value">false, the layout can extend inside the safe area on iOS; true, the layout is constrained outside the safe area</param>
+    [<Extension>]
+    static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IFabLayout>, value: bool) =
+        this.AddScalar(Layout.IgnoreSafeArea.WithValue(value))
 
     /// <summary>Set whether the content is clipped to the layout's bounds</summary>
     /// <param name="this">Current widget</param>
@@ -43,6 +59,11 @@ type LayoutModifiers =
 
 [<Extension>]
 type LayoutExtraModifiers =
+    /// <summary>Allow the layout to extend into the safe area</summary>
+    /// <param name="this">Current widget</param>
+    [<Extension>]
+    static member inline ignoreSafeArea(this: WidgetBuilder<'msg, #IFabLayout>) = this.ignoreSafeArea(false)
+
     /// <summary>Set the padding inside the widget</summary>
     /// <param name="this">Current widget</param>
     /// <param name="uniformSize">The uniform padding value that will be applied to all sides</param>

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuFlyoutItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuFlyoutItem.fs
@@ -1,0 +1,51 @@
+namespace Fabulous.Maui
+
+open System.Runtime.CompilerServices
+open Fabulous
+open Fabulous.StackAllocatedCollections
+open Microsoft.Maui.Controls
+
+type IFabMenuFlyoutItem =
+    inherit IFabMenuItem
+
+module MenuFlyoutItem =
+    let WidgetKey = Widgets.register<MenuFlyoutItem>()
+
+    let KeyboardAccelerators =
+        Attributes.defineListWidgetCollection<KeyboardAccelerator> "KeyboardAccelerators" (fun target -> (target :?> MenuFlyoutItem).KeyboardAccelerators)
+
+[<AutoOpen>]
+module MenuFlyoutItemBuilders =
+    type Fabulous.Maui.View with
+
+        /// <summary>Create a MenuItem widget with a text and a Click callback</summary>
+        /// <param name="text">The text</param>
+        /// <param name="onClicked">The click callback</param>
+        static member inline MenuFlyoutItem<'msg>(text: string, onClicked: 'msg) =
+            WidgetBuilder<'msg, IFabMenuFlyoutItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
+
+[<Extension>]
+type MenuFlyoutItemModifiers =
+    /// <summary>Set the keyboard accelerators of this widget</summary>
+    /// <param name="this">Current widget</param>
+    [<Extension>]
+    static member inline keyboardAccelerators<'msg, 'marker when 'marker :> IFabMenuFlyoutItem>(this: WidgetBuilder<'msg, 'marker>) =
+        WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabKeyboardAccelerator> MenuFlyoutItem.KeyboardAccelerators this
+
+[<Extension>]
+type MenuFlyoutItemYieldExtensions =
+    [<Extension>]
+    static member inline Yield
+        (
+            _: AttributeCollectionBuilder<'msg, #IFabMenuFlyoutItem, IFabKeyboardAccelerator>,
+            x: WidgetBuilder<'msg, #IFabKeyboardAccelerator>
+        ) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }
+
+    [<Extension>]
+    static member inline Yield
+        (
+            _: AttributeCollectionBuilder<'msg, #IFabMenuFlyoutItem, IFabKeyboardAccelerator>,
+            x: WidgetBuilder<'msg, Memo.Memoized<#IFabKeyboardAccelerator>>
+        ) : Content<'msg> =
+        { Widgets = MutStackArray1.One(x.Compile()) }

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
@@ -1,5 +1,7 @@
 namespace Fabulous.Maui
 
+#nowarn "0044" // Disable obsolete warnings in Fabulous.MauiControls. Please remove after deleting obsolete code.
+
 open System
 open System.IO
 open System.Runtime.CompilerServices
@@ -12,6 +14,7 @@ type IFabMenuItem =
 module MenuItem =
     let WidgetKey = Widgets.register<MenuItem>()
 
+    [<Obsolete("MenuItem.Accelerator is obsolete in Maui and might be removed soon. Use MenuFlyoutItem.KeyboardAccelerators instead.")>]
     let Accelerator = Attributes.defineBindableWithEquality MenuItem.AcceleratorProperty
 
     let Clicked =
@@ -40,6 +43,7 @@ type MenuItemModifiers =
     /// <param name="this">Current widget</param>
     /// <param name="value">The accelerator value</param>
     [<Extension>]
+    [<Obsolete("Modifier accelerator is obsolete in Maui and might be removed soon. Please use MenuFlyoutItem.keyboardAccelerators instead.")>]
     static member inline accelerator(this: WidgetBuilder<'msg, #IFabMenuItem>, value: Accelerator) =
         this.AddScalar(MenuItem.Accelerator.WithValue(value))
 

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -58,7 +58,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FSharpCorePkgVersion",
-      "defaultValue": "8.0.100-beta.23418.2"
+      "defaultValue": "8.0.100"
     },
     "FSharpMauiWinUICompatPkgVersion": {
       "type": "parameter",
@@ -70,7 +70,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "MicrosoftMauiControlsPkgVersion",
-      "defaultValue": "8.0.0-rc.1.9171"
+      "defaultValue": "8.0.3"
     }
   }
 }

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -60,17 +60,17 @@
       "replaces": "FSharpCorePkgVersion",
       "defaultValue": "7.0.0"
     },
-    "FSharpAndroidResourcePkgVersion": {
-      "type": "parameter",
-      "dataType": "string",
-      "replaces": "FSharpAndroidResourcePkgVersion",
-      "defaultValue": "1.0.4"
-    },
     "FSharpMauiWinUICompatPkgVersion": {
       "type": "parameter",
       "dataType": "string",
       "replaces": "FSharpMauiWinUICompatPkgVersion",
       "defaultValue": "1.1.0"
+    },
+    "MicrosoftMauiControlsPkgVersion": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "MicrosoftMauiControlsPkgVersion",
+      "defaultValue": "8.0.0-preview.7.8842"
     }
   }
 }

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -58,7 +58,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FSharpCorePkgVersion",
-      "defaultValue": "7.0.0"
+      "defaultValue": "8.0.100-beta.23418.2"
     },
     "FSharpMauiWinUICompatPkgVersion": {
       "type": "parameter",
@@ -70,7 +70,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "MicrosoftMauiControlsPkgVersion",
-      "defaultValue": "8.0.0-preview.7.8842"
+      "defaultValue": "8.0.0-rc.1.9171"
     }
   }
 }

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>NewApp</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -64,8 +64,6 @@
     <AndroidManifest Include="$(AndroidProjectFolder)AndroidManifest.xml" />
     <Compile Include="$(AndroidProjectFolder)MainActivity.fs" />
     <Compile Include="$(AndroidProjectFolder)MainApplication.fs" />
-
-    <PackageReference Include="FSharp.Android.Resource" Version="FSharpAndroidResourcePkgVersion" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetPlatformIdentifier) == 'ios'">
@@ -98,6 +96,8 @@
     <PackageReference Include="Fabulous" Version="FabulousPkgVersion" />
     <PackageReference Include="Fabulous.MauiControls" Version="FabulousMauiControlsPkgVersion" />
     <PackageReference Include="FSharp.Core" Version="FSharpCorePkgVersion" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="MicrosoftMauiControlsPkgVersion" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="MicrosoftMauiControlsPkgVersion" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With the stable release of .NET 8.0, we can release a new version of Fabulous.MauiControls targeting this new runtime.
Because of the tight dependency between .NET MAUI and the .NET Runtime, I bumped the version of Fabulous.MauiControls to 8.0.0.