### PR TITLE
Support for EnvironmentContext inside Components

### DIFF
--- a/Components.md
+++ b/Components.md
@@ -1,0 +1,351 @@
+# Components API architecture
+
+- Introduction (What are today's limitations, what's a component, what's the goals: seamless integration, performance (low memory allocation, localized reevaluation), state management agnostic, environment support)
+- Components
+  - Component basic ideas (seamless integration into current API, holds its own state, internal loop with reevaluation on context change, communication from and to the parent, state management agnostic)
+  - Component building blocks (CE builder, delegates, aggressive inlining, backing context, context invalidation)
+  - Implementation details of ComponentContext, Component, and ComponentBuilder (context uses incremental indices, builder makes use of F# compiler capabilities to calculate while inlining)
+- State management
+  - State basic ideas (top -> down only, stored on the backing context, let! to access the context implicitly, invalidation on context change)
+  - Implementation details of State<'T> and StateValue<'T> with Bind extension to ComponentBuilder (how to avoid capturing short lived StateValue)
+  - Implementation details of Binding<'T> and BindingValue<'T> with Bind extension to ComponentBuilder (how to avoid capturing short lived BindingValue)
+  - Implementation details of MvuComponent (compatibility with non-dispatch existing API)
+- Environment
+  - Environment basic ideas (Implicit context, localized overrides, can invalidate component on system changes, top -> down only)
+  - Implementation details of EnvironmentKey, EnvironmentContext, Environment<'T>, EnvironmentValue<'T>
+
+
+This document aims to describe in details the new Components API that we are introducing for Fabulous 2.
+
+Please note this new API is still Work in Progress and might differ consequently before it becomes stable.
+
+## Introduction
+
+### Why introduce a new Components API?
+
+Today in Fabulous, there is only one source of truth for the whole app: it's root state.
+
+Whenever a change happens in this root state, the whole view hierarchy is re-evaluated to check for any
+UI update that needs to be applied on the screen. Having this single source of truth is great to ensure consistency,
+but it implies a lot of unnecessary processing because 99% of the time a state change will only have an impact locally,
+not globally, hence it would be better to only re-evaluate the local view hierarchy.
+
+This idea is known as "components": you can see them as some kind of mini-apps managing their own local state
+that can trigger re-evaluation on their own and that can be composed together to make an actual Fabulous application.
+
+Despite quite a lot of prior arts (SwiftUI "View" protocol, React components, FuncUI components, Vide builders, etc.),
+it has been difficult to come up with a component approach in Fabulous due to the unique set of constraints: mobile & F#.
+While the implementation is straightforward in the other F# libraries (FuncUI, Vide), they make heavy use of closures
+which allocate of lot of memory; something Fabulous cannot afford because GC would keep freezing the app
+on lower end Android smartphones due to limited memory. Hence it is better to avoid closures and make heavy use
+of structs instead of classes.
+
+Also another aspect why it has been difficult to come up with anything is the opinionated ergonomics wanted for Fabulous.
+Fabulous took a similar approach to SwiftUI: a builder pattern with handcrafted widgets and modifiers.
+But contrary to Swift, in .NET (C# & F#) using interfaces (protocols in Swift) over struct will result in boxing because
+a struct first need to be transformed into an object before being casted to the interface. This triggers a lot of memory
+allocation, which is what we want to avoid in the first place with the structs, so a different approach is required.
+
+```fs
+type IComponent =
+    interface end
+    
+type [<Struct>] TextWidget(value: string) =
+    interface IComponent
+
+let component: IComponent = TextWidget("Hello")
+ // => let component = box(TextWidget(...)) :> IComponent
+```
+
+Another point we want to take a look into is the ability to use any kind of state management, not only MVU.
+
+With all those constraints in place, we want something that can easily be composed into Fabulous 2 DSL ergonomics,
+lets you choose your own state management, and almost allocation-free to be friendly with low end mobile devices.
+
+This means we need to make heavy use of inlining and structs.
+Computation expressions to the rescue.
+
+### What are the goals of the new Components API?
+
+With this new API, we hope to achieve several goals:
+- Seamless integration into the existing View DSL
+- Faster updates via localized diffing
+- Support for different state managements, in addition to MVU
+
+We also hope to finally bring the concept of environment to enable access to values between components, without having to pass them explicitly through each layer.
+
+#### Seamless integration into View DSL
+
+The primary UI building block in Fabulous is the `Widget` struct. It is a very simple description of what should be shown on the screen, and can be easily composed together to create a whole UI tree.
+It is therefore cheap to recreate the whole widget tree on each update. Due to this ephemeral nature, a widget cannot hold any mutating state by itself.
+
+This role is achieved by `Runner`. It takes care of the MVU loop and retains the current state of the app over each update.
+
+Like explained above, components are meant to be similar to `Runner`, but are only in charge of one part of the UI contrary to `Runner`.
+
+A typical Fabulous application will be composed of a lot of different components, so they need to be easily composable with the existing View DSL.
+
+```fs
+let costLists() =
+    Component() {
+        let! costs = (...)
+        
+        VStack() {
+            Label("List of costs")
+            ListView(costs) (fun item -> (...))
+        }
+    }
+
+let costSummary() =
+    Component() {
+        let! summary = (...)
+
+        HStack() {
+            Label("Cost summary")
+            Label(...)
+        }
+    }
+
+let view() =
+    VStack() {
+        Label("My Counter app")
+        costLists()
+        costSummary()
+    }
+```
+
+### Faster updates via localized diffing
+
+Because Fabulous uses a single source of truth for the whole UI state, it needs to diff the whole widget tree on each update. This results in a lot of unnecessary processing when most typical user interactions have an impact locally on the UI, rather than globally.
+
+Despite doing as much performance optimizations as we could, we are still wasting a lot of CPU cycles toward processing the whole UI tree, potentially just to update a deeply nested text.
+
+This is where the new Components API comes in.
+
+It brings local sources of truth (the component state) and allow for localized updates.
+
+When used properly, the Components API can drastically improve performance of apps.
+
+```fs
+let counter() =
+    Component() {
+        // Updating this count will only reevaluate
+        // the current component and its children.
+        // Parent widgets won't be reevaluated
+        let! count = State(0)
+
+        Button(
+            $"Count is {count.Current}",
+            fun() -> count.Set(count.Current + 1)
+        )
+    }
+
+let view() =
+    Application() {
+        VStack() {
+            VStack() {
+                (...) {
+                    // Somewhere very deep
+                    counter()
+                }
+            }
+        }
+    }
+```
+
+### Support for different state managements
+
+From the start, Fabulous was modeled after Elm. It was meant to be used exclusively with MVU because it was fitting very nicely into the whole architectural model wanted with Fabulous.
+
+As nice as MVU is, over time its flaws became really apparent, especially in bigger apps where manually composing the init, updates and view functions can be really annoying and very verbose.
+
+The new Components API opens up the possibilities in terms of state management.
+
+Components have their own internal context which when updated triggers a reevaluation of the component.
+
+This can be levied by most existing state management approach, such as MVU, MVVM, MVC, and so on.
+
+```fs
+let stateCounter () =
+    Component() {
+        let! count = State(0)
+
+        VStack() {
+            Label($"Count is {count.Current}")
+            Button("Increment", fun () -> count.Set(count.Current + 1))
+            Button("Decrement", fun () -> count.Set(count.Current - 1))
+        }
+    }
+
+let mvvmCounter () =
+    Component() {
+        let! vm = CounterViewModel()
+
+        VStack() {
+            Label($"Count is {vm.Count}")
+            Button("Increment", fun () -> vm.Increment())
+            Button("Decrement", fun () -> vm.Decrement())
+        }
+    }
+
+let mvuCounter() =
+    MvuComponent(init, update) {
+        let! model = Mvu.State
+
+        VStack() {
+            Label($"Count is {model.Count}")
+            Button("Increment", Msg.Increment)
+            Button("Decrement", Msg.Decrement)
+        }
+    }
+```
+
+### Environment context
+
+_Declaring an Environment value_
+
+```fs
+type Service() =
+    member this.DoSomething() = ()
+
+let ServiceKey = EnvironmentKey("Service", Service())
+
+type EnvironmentContext with
+    member this.Service
+        with get () = this[ServiceKey]
+        and set value = this[ServiceKey] <- value
+```
+
+_Reading an Environment value_
+
+```fs
+let view() =
+    Component() {
+        let! service = Environment(ServiceKey)
+        Button("Do Something", fun () -> service.DoSomething())
+    }
+```
+
+_Overriding an Environment value_
+
+```fs
+let view() =
+    (Component() {
+        (...)
+    })
+        .environment(ServiceKey, CustomService())
+```
+
+_Updating an Environment value with an Observable_
+```fs
+let ThemeKey = EnvironmentKey(AppInfo.RequestedTheme)
+
+type EnvironmentContext with
+    member this.Theme
+        with get () = this[ThemeKey.GetType()] :?> AppTheme
+        and set value = this[ThemeKey.GetType] <- value
+
+module Theme =
+    let register (env: EnvironmentContext) =
+        let fromSource =
+            Application.Current.RequestedThemeChanged.Subscribe(fun args ->
+                env.Theme <- args.Value
+            )
+
+        let toSource =
+            env.ValueChanged.Subscribe(fun args ->
+                if args.Key = ThemeKey.GetType() then
+                    Application.Current.RequestedTheme <- args.Value
+            )
+
+        { new System.IDisposable() with
+            member this.Dispose() =
+                fromSource.Dispose()
+                toSource.Dispose() }
+
+let view() =
+    (Component() {
+        let! theme = Environment(EnvironmentKeys.Theme)
+
+        Label("Theme is %A{theme.Current}")
+    })
+        .onInit(Theme.register)
+```
+
+## Components API
+
+### Core ideas
+
+- Holds its own state
+- Internal loop with reevaluation on context change
+- Communication from and to the parent
+- How state management agnostic is achieved
+
+### Building blocks
+
+- CE builder
+- Delegates
+- Aggressive inlining
+- Backing context
+- Context invalidation
+
+### Implementation
+
+- ComponentContext
+- Component
+- ComponentBuilder
+- Context uses incremental indices
+- Builder makes use of F# compiler capabilities to calculate while inlining
+
+## State management
+
+### Core ideas
+
+- Top -> down only
+- Stored on the backing context
+- `let!` to access the context implicitly
+  - Request struct objects in user code
+  - Response struct returned after bind. contains current value and potential updater
+  - to avoid capturing structs in closures, inline all members
+- Invalidation on context change
+
+### Local state with State<'T>
+
+- Usage
+- State<'T>
+- StateValue<'T>
+- Bind extension to ComponentBuilder
+- How to avoid capturing short lived StateValue
+
+### Shared state between parent and child with Binding<'T>
+
+- Usage
+- Binding<'T>
+- BindingValue<'T>
+- Bind extension to ComponentBuilder
+- How to avoid capturing short lived BindingValue
+
+### Supporting MVU with the specialized MvuComponent
+
+- Usage
+- Compatibility with non-dispatch existing API
+
+## Environment
+
+### Core ideas
+
+- Implicit context
+- Localized overrides
+- Can invalidate component on system changes
+- Top -> down only
+
+### Ambient state with Environment<'T>
+
+- Usage
+- EnvironmentKey
+- EnvironmentContext
+- Environment<'T>
+- EnvironmentValue<'T>
+- Bind extension to ComponentBuilder
+
+### Implementation

--- a/Fabulous.MauiControls.sln
+++ b/Fabulous.MauiControls.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Files", "_Solutio
 					release.yml = .github/workflows/release.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		Components.md = Components.md
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Gallery", "samples\Gallery\Gallery.fsproj", "{A28D6852-F21C-4A43-93AF-CC71050028A9}"

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -9,45 +9,51 @@ open type Fabulous.Maui.View
 [<AutoOpen>]
 module AppEnvironmentKeys =
     let CountKey = EnvironmentKey("Count", 0)
+
     type EnvironmentKeys with
+
         static member Count = CountKey
 
 open type Fabulous.Maui.EnvironmentKeys
 
 module App =
-    let themeViewer() =
+    let themeViewer () =
         Component() {
             let! theme = Environment(Theme)
-            
+
             VStack() {
                 Label($"[themeViewer] Current theme is %A{theme.Current}")
-                Button("[themeViewer] Toggle theme", fun () ->
-                    theme.Set(
-                        if theme.Current = AppTheme.Light then
-                            AppTheme.Dark
-                        else
-                            AppTheme.Light
-                    )
+
+                Button(
+                    "[themeViewer] Toggle theme",
+                    fun () ->
+                        theme.Set(
+                            if theme.Current = AppTheme.Light then
+                                AppTheme.Dark
+                            else
+                                AppTheme.Light
+                        )
                 )
             }
         }
-    
-    let subCountViewer() =
+
+    let subCountViewer () =
         Component() {
             let! count = Environment(Count)
             Label($"[SubCountViewer] Count = {count.Current}")
         }
-    
-    let subCountSetter() =
+
+    let subCountSetter () =
         Component() {
             let! count = Environment(Count)
+
             VStack() {
-                Button("[SubCountSetter] Increment", fun () -> count.Set(count.Current + 1))
-                Button("[SubCountSetter] Decrement", fun () -> count.Set(count.Current - 1))
+                Button("[SubCountSetter] Increment", (fun () -> count.Set(count.Current + 1)))
+                Button("[SubCountSetter] Decrement", (fun () -> count.Set(count.Current - 1)))
             }
         }
-        
-    let subCount() =
+
+    let subCount () =
         (Component() {
             VStack() {
                 subCountViewer()
@@ -55,25 +61,24 @@ module App =
             }
         })
             .environment(Count, 10)
-        
-    let countViewer() =
+
+    let countViewer () =
         Component() {
             let! count = Environment(Count)
-            VStack() {
-                Label($"[CountViewer] Count = {count.Current}")
-            }
+            VStack() { Label($"[CountViewer] Count = {count.Current}") }
         }
-        
-    let countSetter() =
+
+    let countSetter () =
         Component() {
             let! count = Environment(Count)
+
             VStack() {
-                Button("[CountSetter] Increment", fun () -> count.Set(count.Current + 1))
-                Button("[CountSetter] Decrement", fun () -> count.Set(count.Current - 1))
+                Button("[CountSetter] Increment", (fun () -> count.Set(count.Current + 1)))
+                Button("[CountSetter] Decrement", (fun () -> count.Set(count.Current - 1)))
             }
         }
-        
-    let count'() =
+
+    let count' () =
         Component() {
             VStack() {
                 countViewer()
@@ -81,18 +86,19 @@ module App =
             }
         }
 
-    let view() =
+    let view () =
         (Component() {
             let! count = Environment(Count)
             let! theme = Environment(Theme)
+
             Application() {
                 ContentPage() {
                     VStack() {
                         Label($"[view] Current theme is %A{theme.Current}")
                         Label($"[view] Count = {count.Current}")
-                        Button("[view] Increment", fun () -> count.Set(count.Current + 1))
-                        Button("[view] Decrement", fun () -> count.Set(count.Current - 1))
-                        
+                        Button("[view] Increment", (fun () -> count.Set(count.Current + 1)))
+                        Button("[view] Decrement", (fun () -> count.Set(count.Current - 1)))
+
                         count'()
                         subCount()
                         themeViewer()
@@ -101,8 +107,8 @@ module App =
             }
         })
             .environment(Count, 0)
-    
-    let createMauiApp() =
+
+    let createMauiApp () =
         MauiApp
             .CreateBuilder()
             .UseFabulousApp(view)

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -6,8 +6,8 @@ open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
 module EnvironmentKeys =
-    let LetsTry = EnvironmentKey "letsTry"
-    let LetsTry2 = EnvironmentKey "letsTry2"
+    let LetsTry = EnvironmentKey.Create<int>("letsTry")
+    let LetsTry2 = EnvironmentKey.Create<int>("letsTry2")
 
 module App =
     [<Literal>]
@@ -17,8 +17,8 @@ module App =
     
     let grandChild() =
         Component() {
-            let! letsTryValue = Environment.Get<int>(EnvironmentKeys.LetsTry)
-            let! letsTryValue2 = Environment.Get<int>(EnvironmentKeys.LetsTry2)
+            let! letsTryValue = Environment.Get(EnvironmentKeys.LetsTry)
+            let! letsTryValue2 = Environment.Get(EnvironmentKeys.LetsTry2)
             
             (VStack() {
                 Label($"Environment value 1 is {letsTryValue}")
@@ -31,7 +31,7 @@ module App =
         
     let child() =
         Component() {
-            let! valueBeforeOverriding = Environment.Get<int>(EnvironmentKeys.LetsTry)
+            let! valueBeforeOverriding = Environment.Get(EnvironmentKeys.LetsTry)
             do! Environment.Set(EnvironmentKeys.LetsTry, 100)
             do! Environment.Set(EnvironmentKeys.LetsTry2, 15)
             

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -5,6 +5,10 @@ open Fabulous.Maui
 open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
+module EnvironmentKeys =
+    let LetsTry = EnvironmentKey "letsTry"
+    let LetsTry2 = EnvironmentKey "letsTry2"
+
 module App =
     [<Literal>]
     let letsTry = "key"
@@ -13,8 +17,8 @@ module App =
     
     let grandChild() =
         Component() {
-            let! letsTryValue = Environment.Get<int>(letsTry)
-            let! letsTryValue2 = Environment.Get<int>(letsTry2)
+            let! letsTryValue = Environment.Get<int>(EnvironmentKeys.LetsTry)
+            let! letsTryValue2 = Environment.Get<int>(EnvironmentKeys.LetsTry2)
             
             (VStack() {
                 Label($"Environment value 1 is {letsTryValue}")
@@ -27,18 +31,22 @@ module App =
         
     let child() =
         Component() {
-            do! Environment.Set(letsTry2, 15)
+            let! valueBeforeOverriding = Environment.Get<int>(EnvironmentKeys.LetsTry)
+            do! Environment.Set(EnvironmentKeys.LetsTry, 100)
+            do! Environment.Set(EnvironmentKeys.LetsTry2, 15)
             
             VStack() {
                 Label("Child")
                     .center()
+                    
+                Label($"Environment value before overriding is {valueBeforeOverriding}")
                 grandChild()
             }
         }
     
     let view() =
         Component() {
-            do! Environment.Set(letsTry, 10)
+            do! Environment.Set(EnvironmentKeys.LetsTry, 10)
             
             Application() {
                 ContentPage() {

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -2,68 +2,62 @@ namespace HelloComponent
 
 open Fabulous
 open Fabulous.Maui
+open Microsoft.Maui.ApplicationModel
+open Microsoft.Maui.Graphics
 open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
-module EnvironmentKeys =
-    let LetsTry = EnvironmentKey.Create<int>("letsTry")
-    let LetsTry2 = EnvironmentKey.Create<int>("letsTry2")
-
 module App =
-    [<Literal>]
-    let letsTry = "key"
-    [<Literal>]
-    let letsTry2 = "key2"
-    
-    let grandChild() =
+    let themeViewer() =
         Component() {
-            let! letsTryValue = Environment.Get(EnvironmentKeys.LetsTry)
-            let! letsTryValue2 = Environment.Get(EnvironmentKeys.LetsTry2)
-            
-            (VStack() {
-                Label($"Environment value 1 is {letsTryValue}")
-                    .center()
-                Label($"Environment value 2 is {letsTryValue2}")
-                    .center()
-            })
+            printfn "Evaluated themeViewer()"
+            let! theme = Environment(EnvironmentKeys.Theme)
+            Label($"Theme is {theme.Current}")
                 .center()
         }
         
-    let child() =
+    let themeSetter() =
         Component() {
-            let! valueBeforeOverriding = Environment.Get(EnvironmentKeys.LetsTry)
-            do! Environment.Set(EnvironmentKeys.LetsTry, 100)
-            do! Environment.Set(EnvironmentKeys.LetsTry2, 15)
-            
+            printfn "Evaluated themeSetter()"
+            let! theme = Environment(EnvironmentKeys.Theme)
             VStack() {
-                Label("Child")
-                    .center()
+                Button("Change theme", fun () ->
+                    let newTheme =
+                        match theme.Current with
+                        | AppTheme.Light -> AppTheme.Dark
+                        | _ -> AppTheme.Light
                     
-                Label($"Environment value before overriding is {valueBeforeOverriding}")
-                grandChild()
+                    theme.Set(newTheme)
+                )
+                
+                Button("Unset theme", fun () ->
+                    theme.Set(AppTheme.Unspecified)
+                )
             }
         }
-    
-    let view() =
+        
+    let themeViewerAndSetter() =
         Component() {
-            do! Environment.Set(EnvironmentKeys.LetsTry, 10)
-            
-            Application() {
-                ContentPage() {
-                    (VStack() {
-                        Label("Parent")
-                            .center()
-                        child()
-                    })
-                        .center()
-                }
+            printfn "Evaluated themeViewerAndSetter()"
+            (VStack() {
+                themeViewer()
+                themeSetter()
+            })
+                .center()
+        }
+
+    let view() =
+        printfn "Evaluated view()"
+        Application() {
+            ContentPage() {
+                themeViewerAndSetter()
             }
         }
     
     let createMauiApp() =
         MauiApp
             .CreateBuilder()
-            .UseFabulousApp(view())
+            .UseFabulousApp(view)
             .ConfigureFonts(fun fonts ->
                 fonts
                     .AddFont("OpenSans-Regular.ttf", "OpenSansRegular")

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -6,8 +6,31 @@ open Microsoft.Maui.ApplicationModel
 open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
+[<AutoOpen>]
+module AppEnvironmentKeys =
+    let CountKey = EnvironmentKey("Count", 0)
+    type EnvironmentKeys with
+        static member Count = CountKey
+
+open type Fabulous.Maui.EnvironmentKeys
+
 module App =
-    let Count = EnvironmentKey("Count", 0)
+    let themeViewer() =
+        Component() {
+            let! theme = Environment(Theme)
+            
+            VStack() {
+                Label($"[themeViewer] Current theme is %A{theme.Current}")
+                Button("[themeViewer] Toggle theme", fun () ->
+                    theme.Set(
+                        if theme.Current = AppTheme.Light then
+                            AppTheme.Dark
+                        else
+                            AppTheme.Light
+                    )
+                )
+            }
+        }
     
     let subCountViewer() =
         Component() {
@@ -61,15 +84,18 @@ module App =
     let view() =
         (Component() {
             let! count = Environment(Count)
+            let! theme = Environment(Theme)
             Application() {
                 ContentPage() {
                     VStack() {
+                        Label($"[view] Current theme is %A{theme.Current}")
                         Label($"[view] Count = {count.Current}")
                         Button("[view] Increment", fun () -> count.Set(count.Current + 1))
                         Button("[view] Decrement", fun () -> count.Set(count.Current - 1))
                         
                         count'()
                         subCount()
+                        themeViewer()
                     }
                 }
             }

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -3,56 +3,78 @@ namespace HelloComponent
 open Fabulous
 open Fabulous.Maui
 open Microsoft.Maui.ApplicationModel
-open Microsoft.Maui.Graphics
 open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
 module App =
-    let themeViewer() =
+    let Count = EnvironmentKey("Count", 0)
+    
+    let subCountViewer() =
         Component() {
-            printfn "Evaluated themeViewer()"
-            let! theme = Environment(EnvironmentKeys.Theme)
-            Label($"Theme is {theme.Current}")
-                .center()
+            let! count = Environment(Count)
+            Label($"[SubCountViewer] Count = {count.Current}")
         }
-        
-    let themeSetter() =
+    
+    let subCountSetter() =
         Component() {
-            printfn "Evaluated themeSetter()"
-            let! theme = Environment(EnvironmentKeys.Theme)
+            let! count = Environment(Count)
             VStack() {
-                Button("Change theme", fun () ->
-                    let newTheme =
-                        match theme.Current with
-                        | AppTheme.Light -> AppTheme.Dark
-                        | _ -> AppTheme.Light
-                    
-                    theme.Set(newTheme)
-                )
-                
-                Button("Unset theme", fun () ->
-                    theme.Set(AppTheme.Unspecified)
-                )
+                Button("[SubCountSetter] Increment", fun () -> count.Set(count.Current + 1))
+                Button("[SubCountSetter] Decrement", fun () -> count.Set(count.Current - 1))
             }
         }
         
-    let themeViewerAndSetter() =
+    let subCount() =
+        (Component() {
+            VStack() {
+                subCountViewer()
+                subCountSetter()
+            }
+        })
+            .environment(Count, 10)
+        
+    let countViewer() =
         Component() {
-            printfn "Evaluated themeViewerAndSetter()"
-            (VStack() {
-                themeViewer()
-                themeSetter()
-            })
-                .center()
+            let! count = Environment(Count)
+            VStack() {
+                Label($"[CountViewer] Count = {count.Current}")
+            }
+        }
+        
+    let countSetter() =
+        Component() {
+            let! count = Environment(Count)
+            VStack() {
+                Button("[CountSetter] Increment", fun () -> count.Set(count.Current + 1))
+                Button("[CountSetter] Decrement", fun () -> count.Set(count.Current - 1))
+            }
+        }
+        
+    let count'() =
+        Component() {
+            VStack() {
+                countViewer()
+                countSetter()
+            }
         }
 
     let view() =
-        printfn "Evaluated view()"
-        Application() {
-            ContentPage() {
-                themeViewerAndSetter()
+        (Component() {
+            let! count = Environment(Count)
+            Application() {
+                ContentPage() {
+                    VStack() {
+                        Label($"[view] Count = {count.Current}")
+                        Button("[view] Increment", fun () -> count.Set(count.Current + 1))
+                        Button("[view] Decrement", fun () -> count.Set(count.Current - 1))
+                        
+                        count'()
+                        subCount()
+                    }
+                }
             }
-        }
+        })
+            .environment(Count, 0)
     
     let createMauiApp() =
         MauiApp

--- a/samples/Components/HelloComponent/App.fs
+++ b/samples/Components/HelloComponent/App.fs
@@ -1,14 +1,58 @@
 namespace HelloComponent
 
+open Fabulous
 open Fabulous.Maui
 open Microsoft.Maui.Hosting
 open type Fabulous.Maui.View
 
 module App =
-    let view () =
-        Component() { Application(ContentPage(Label("Hello from Fabulous for Maui with components!").center())) }
-
-    let createMauiApp () =
+    [<Literal>]
+    let letsTry = "key"
+    [<Literal>]
+    let letsTry2 = "key2"
+    
+    let grandChild() =
+        Component() {
+            let! letsTryValue = Environment.Get<int>(letsTry)
+            let! letsTryValue2 = Environment.Get<int>(letsTry2)
+            
+            (VStack() {
+                Label($"Environment value 1 is {letsTryValue}")
+                    .center()
+                Label($"Environment value 2 is {letsTryValue2}")
+                    .center()
+            })
+                .center()
+        }
+        
+    let child() =
+        Component() {
+            do! Environment.Set(letsTry2, 15)
+            
+            VStack() {
+                Label("Child")
+                    .center()
+                grandChild()
+            }
+        }
+    
+    let view() =
+        Component() {
+            do! Environment.Set(letsTry, 10)
+            
+            Application() {
+                ContentPage() {
+                    (VStack() {
+                        Label("Parent")
+                            .center()
+                        child()
+                    })
+                        .center()
+                }
+            }
+        }
+    
+    let createMauiApp() =
         MauiApp
             .CreateBuilder()
             .UseFabulousApp(view())

--- a/samples/Components/MultipleMvus/App.fs
+++ b/samples/Components/MultipleMvus/App.fs
@@ -67,4 +67,5 @@ module App =
                     .width(250.)
                     .center()
             }
-        }
+        })
+            .withEnvironment(Container, container)

--- a/samples/Components/MultipleMvus/App.fs
+++ b/samples/Components/MultipleMvus/App.fs
@@ -67,5 +67,4 @@ module App =
                     .width(250.)
                     .center()
             }
-        })
-            .withEnvironment(Container, container)
+        }

--- a/samples/Components/MultipleMvus/MauiProgram.fs
+++ b/samples/Components/MultipleMvus/MauiProgram.fs
@@ -7,7 +7,7 @@ type MauiProgram =
     static member CreateMauiApp() =
         MauiApp
             .CreateBuilder()
-            .UseFabulousApp(App.view())
+            .UseFabulousApp(App.view)
             .ConfigureFonts(fun fonts ->
                 fonts
                     .AddFont("OpenSans-Regular.ttf", "OpenSansRegular")

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -32,10 +32,9 @@ type AppHostBuilderExtensions =
                 { CanReuseView = MauiViewHelpers.canReuseView
                   GetViewNode = ViewNode.get
                   Logger = ProgramHelpers.defaultLogger()
-                  Dispatch = ignore
-                  EnvironmentContext = EnvironmentContext() }
+                  Dispatch = ignore }
 
-            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone)
+            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone, ValueNone)
 
             view :?> Microsoft.Maui.IApplication)
 
@@ -51,9 +50,8 @@ type AppHostBuilderExtensions =
                 { CanReuseView = MauiViewHelpers.canReuseView
                   GetViewNode = ViewNode.get
                   Logger = program.Logger
-                  Dispatch = ignore
-                  EnvironmentContext = EnvironmentContext() }
+                  Dispatch = ignore }
 
-            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone)
+            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone, ValueNone)
 
             view :?> Microsoft.Maui.IApplication)

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -21,37 +21,6 @@ type AppHostBuilderExtensions =
             (Program.startApplicationWithArgs arg program) :> Microsoft.Maui.IApplication)
 
     [<Extension>]
-    static member UseFabulousApp(this: MauiAppBuilder, root: WidgetBuilder<unit, #IFabApplication>) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
-            Component.registerComponentFunctions()
-
-            let widget = root.Compile()
-            let widgetDef = WidgetDefinitionStore.get widget.Key
-
-            let viewTreeContext =
-                { CanReuseView = MauiViewHelpers.canReuseView
-                  GetViewNode = ViewNode.get
-                  Logger = ProgramHelpers.defaultLogger()
-                  Dispatch = ignore }
-
-            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone, ValueNone)
-
-            view :?> Microsoft.Maui.IApplication)
-
-    [<Extension>]
-    static member UseFabulousApp(this: MauiAppBuilder, program: Program<'arg, 'model, 'msg>, root: WidgetBuilder<unit, #IFabApplication>) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
-            Component.registerComponentFunctions()
-
-            let widget = root.Compile()
-            let widgetDef = WidgetDefinitionStore.get widget.Key
-
-            let viewTreeContext =
-                { CanReuseView = MauiViewHelpers.canReuseView
-                  GetViewNode = ViewNode.get
-                  Logger = program.Logger
-                  Dispatch = ignore }
-
-            let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone, ValueNone)
-
-            view :?> Microsoft.Maui.IApplication)
+    static member UseFabulousApp(this: MauiAppBuilder, view: unit -> WidgetBuilder<unit, #IFabApplication>) : MauiAppBuilder =
+        let program = Program.stateless view
+        this.UseFabulousApp(program)

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -32,7 +32,8 @@ type AppHostBuilderExtensions =
                 { CanReuseView = MauiViewHelpers.canReuseView
                   GetViewNode = ViewNode.get
                   Logger = ProgramHelpers.defaultLogger()
-                  Dispatch = ignore }
+                  Dispatch = ignore
+                  EnvironmentContext = EnvironmentContext() }
 
             let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone)
 
@@ -50,7 +51,8 @@ type AppHostBuilderExtensions =
                 { CanReuseView = MauiViewHelpers.canReuseView
                   GetViewNode = ViewNode.get
                   Logger = program.Logger
-                  Dispatch = ignore }
+                  Dispatch = ignore
+                  EnvironmentContext = EnvironmentContext() }
 
             let struct (_node, view) = widgetDef.CreateView(widget, viewTreeContext, ValueNone)
 

--- a/src/Fabulous.MauiControls/Component.fs
+++ b/src/Fabulous.MauiControls/Component.fs
@@ -8,9 +8,15 @@ module Component =
         BindableProperty.CreateAttached("Component", typeof<IBaseComponent>, typeof<BindableObject>, null)
 
     let registerComponentFunctions () =
-        Component.setComponentFunctions(
+        BaseComponent.setComponentFunctions(
             (fun view -> (view :?> BindableObject).GetValue(ComponentProperty) :?> IBaseComponent),
-            (fun view comp -> (view :?> BindableObject).SetValue(ComponentProperty, comp))
+            (fun view comp ->
+                let previousComp = BaseComponent.getAttachedComponent view
+                if previousComp <> null then
+                    previousComp.Dispose()
+                    
+                (view :?> BindableObject).SetValue(ComponentProperty, comp)
+            )
         )
 
 [<AutoOpen>]

--- a/src/Fabulous.MauiControls/Component.fs
+++ b/src/Fabulous.MauiControls/Component.fs
@@ -11,20 +11,23 @@ module Component =
         BaseComponent.setComponentFunctions(
             (fun view -> (view :?> BindableObject).GetValue(ComponentProperty) :?> IBaseComponent),
             (fun view comp ->
-                let previousComp = BaseComponent.getAttachedComponent view
+                let previousComp =
+                    (view :?> BindableObject).GetValue(ComponentProperty) :?> IBaseComponent
+
                 if previousComp <> null then
                     previousComp.Dispose()
-                    
-                (view :?> BindableObject).SetValue(ComponentProperty, comp)
-            )
+
+                (view :?> BindableObject).SetValue(ComponentProperty, comp))
         )
 
 [<AutoOpen>]
 module ComponentBuilders =
     type Fabulous.Maui.View with
 
-        static member inline Component<'marker>() = ComponentBuilder()
+        static member inline Component<'msg, 'marker>() = ComponentBuilder<'msg, 'marker>()
 
-        static member inline MvuComponent(program: Program<unit, 'model, 'msg>) = MvuComponentBuilder(program, ())
+        static member inline MvuComponent<'msg, 'marker, 'cMsg, 'cModel>(program: Program<unit, 'cModel, 'cMsg>) =
+            MvuComponentBuilder<'msg, 'marker, unit, 'cMsg, 'cModel>(program, ())
 
-        static member inline MvuComponent(program: Program<'arg, 'model, 'msg>, arg: 'arg) = MvuComponentBuilder(program, arg)
+        static member inline MvuComponent<'msg, 'marker, 'cArg, 'cMsg, 'cModel>(program: Program<'cArg, 'cModel, 'cMsg>, arg: 'cArg) =
+            MvuComponentBuilder<'msg, 'marker, 'cArg, 'cMsg, 'cModel>(program, arg)

--- a/src/Fabulous.MauiControls/Environment.fs
+++ b/src/Fabulous.MauiControls/Environment.fs
@@ -1,0 +1,58 @@
+namespace Fabulous.Maui
+
+open System
+open Fabulous
+open Microsoft.Maui.ApplicationModel
+open Microsoft.Maui.Controls
+
+open type Fabulous.Maui.View
+
+[<AbstractClass; Sealed>]
+type EnvironmentKeys =
+    class end
+
+module Theme =
+    let Key = EnvironmentKey("Theme", AppInfo.RequestedTheme)
+    
+    let initialize (env: EnvironmentContext) =
+        env.Set(Key, Key.DefaultValue, false)
+    
+    let subscribe (env: EnvironmentContext) (target: obj) =
+        let app = target :?> Application
+        
+        let fromSource =
+            app.RequestedThemeChanged.Subscribe(fun args ->
+                env.Set(Key, args.RequestedTheme, false)
+            )
+            
+        let toSource =
+            env.ValueChanged.Subscribe(fun args ->
+                if args.Key = Key.Key && args.FromUserCode = true then
+                    let newValue =
+                        match args.Value with
+                        | ValueNone -> AppTheme.Unspecified
+                        | ValueSome value -> value :?> AppTheme
+                        
+                    app.UserAppTheme <- newValue
+            )
+        
+        { new IDisposable with
+            member _.Dispose() =
+                fromSource.Dispose()
+                toSource.Dispose() }
+
+[<AutoOpen>]
+module EnvironmentBuilders =
+    type EnvironmentKeys with
+        static member Theme = Theme.Key
+
+module EnvironmentHelpers =
+    let initialize (env: EnvironmentContext) =
+        Theme.initialize env
+        
+    let subscribe (env: EnvironmentContext, target: obj) =
+        let theme = Theme.subscribe env target
+        
+        { new IDisposable with
+            member _.Dispose() =
+                theme.Dispose() }

--- a/src/Fabulous.MauiControls/Environment.fs
+++ b/src/Fabulous.MauiControls/Environment.fs
@@ -9,22 +9,20 @@ open type Fabulous.Maui.View
 
 [<AbstractClass; Sealed>]
 type EnvironmentKeys =
-    class end
+    class
+    end
 
 module Theme =
     let Key = EnvironmentKey("Theme", AppInfo.RequestedTheme)
-    
-    let initialize (env: EnvironmentContext) =
-        env.Set(Key, Key.DefaultValue, false)
-    
+
+    let initialize (env: EnvironmentContext) = env.Set(Key, Key.DefaultValue, false)
+
     let subscribe (env: EnvironmentContext) (target: obj) =
         let app = target :?> Application
-        
+
         let fromSource =
-            app.RequestedThemeChanged.Subscribe(fun args ->
-                env.Set(Key, args.RequestedTheme, false)
-            )
-            
+            app.RequestedThemeChanged.Subscribe(fun args -> env.Set(Key, args.RequestedTheme, false))
+
         let toSource =
             env.ValueChanged.Subscribe(fun args ->
                 if args.Key = Key.Key && args.FromUserCode = true then
@@ -32,10 +30,9 @@ module Theme =
                         match args.Value with
                         | ValueNone -> AppTheme.Unspecified
                         | ValueSome value -> value :?> AppTheme
-                        
-                    app.UserAppTheme <- newValue
-            )
-        
+
+                    app.UserAppTheme <- newValue)
+
         { new IDisposable with
             member _.Dispose() =
                 fromSource.Dispose()
@@ -44,15 +41,14 @@ module Theme =
 [<AutoOpen>]
 module EnvironmentBuilders =
     type EnvironmentKeys with
+
         static member Theme = Theme.Key
 
 module EnvironmentHelpers =
-    let initialize (env: EnvironmentContext) =
-        Theme.initialize env
-        
+    let initialize (env: EnvironmentContext) = Theme.initialize env
+
     let subscribe (env: EnvironmentContext, target: obj) =
         let theme = Theme.subscribe env target
-        
+
         { new IDisposable with
-            member _.Dispose() =
-                theme.Dispose() }
+            member _.Dispose() = theme.Dispose() }

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="Views\_Semantics.fs" />
     <Compile Include="ThemeAware.fs" />
     <Compile Include="Component.fs" />
+    <Compile Include="Environment.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="Async.fs" />
     <Compile Include="AppHostBuilderExtensions.fs" />

--- a/src/Fabulous.MauiControls/Program.fs
+++ b/src/Fabulous.MauiControls/Program.fs
@@ -84,11 +84,12 @@ module Program =
                 fun (env, target) ->
                     let fab = program.Environment.Subscribe(env, target)
                     let maui = EnvironmentHelpers.subscribe(env, target)
+
                     { new IDisposable with
                         member this.Dispose() =
                             fab.Dispose()
                             maui.Dispose() } }
-        
+
         { Program = { program with Environment = env }
           View = view
           CanReuseView = MauiViewHelpers.canReuseView

--- a/src/Fabulous.MauiControls/Program.fs
+++ b/src/Fabulous.MauiControls/Program.fs
@@ -1,5 +1,6 @@
 ﻿namespace Fabulous.Maui
 
+open System
 open Fabulous
 open Fabulous.ScalarAttributeDefinitions
 open Fabulous.WidgetCollectionAttributeDefinitions
@@ -74,7 +75,21 @@ module MauiViewHelpers =
 
 module Program =
     let inline private define (view: 'model -> WidgetBuilder<'msg, 'marker>) (program: Program<'arg, 'model, 'msg>) : Program<'arg, 'model, 'msg, 'marker> =
-        { Program = program
+        let env =
+            { Initialize =
+                fun env ->
+                    program.Environment.Initialize(env)
+                    EnvironmentHelpers.initialize(env)
+              Subscribe =
+                fun (env, target) ->
+                    let fab = program.Environment.Subscribe(env, target)
+                    let maui = EnvironmentHelpers.subscribe(env, target)
+                    { new IDisposable with
+                        member this.Dispose() =
+                            fab.Dispose()
+                            maui.Dispose() } }
+        
+        { Program = { program with Environment = env }
           View = view
           CanReuseView = MauiViewHelpers.canReuseView
           SyncAction = MainThread.BeginInvokeOnMainThread }
@@ -154,7 +169,8 @@ module Program =
     /// Allow the app to react to theme changes
     let withThemeAwareness (program: Program<'arg, 'model, 'msg, #IFabApplication>) =
         { Program =
-            { Init = ThemeAwareProgram.init program.Program.Init
+            { Environment = program.Program.Environment
+              Init = ThemeAwareProgram.init program.Program.Init
               Update = ThemeAwareProgram.update program.Program.Update
               Subscribe = fun model -> program.Program.Subscribe model.Model |> Cmd.map ThemeAwareProgram.Msg.ModelMsg
               Logger = program.Program.Logger

--- a/src/Fabulous.MauiControls/Views/Application.fs
+++ b/src/Fabulous.MauiControls/Views/Application.fs
@@ -1,6 +1,7 @@
 ﻿namespace Fabulous.Maui
 
 open System
+open System.Reflection
 open System.Runtime.CompilerServices
 open Fabulous
 open Microsoft.Maui.Controls

--- a/src/Fabulous.MauiControls/VirtualizedCollection.fs
+++ b/src/Fabulous.MauiControls/VirtualizedCollection.fs
@@ -33,7 +33,7 @@ type WidgetDataTemplate(parent: IViewNode, ``type``: Type, templateFn: obj -> Wi
             let bindableObject = Activator.CreateInstance ``type`` :?> BindableObject
 
             let viewNode =
-                ViewNode(Some parent, parent.TreeContext, WeakReference(bindableObject))
+                ViewNode(Some parent, parent.TreeContext, parent.EnvironmentContext, WeakReference(bindableObject))
 
             bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
 

--- a/src/Fabulous.MauiControls/Widgets.fs
+++ b/src/Fabulous.MauiControls/Widgets.fs
@@ -33,11 +33,6 @@ module Widgets =
                         match parentNode with
                         | ValueNone -> None
                         | ValueSome node -> Some node
-                        
-                    let env =
-                        match env with
-                        | ValueNone -> EnvironmentContext()
-                        | ValueSome env -> env // Only Components needs to create a new environment
 
                     let node = ViewNode(parentNode, treeContext, env, weakReference)
 
@@ -58,11 +53,6 @@ module Widgets =
                         match parentNode with
                         | ValueNone -> None
                         | ValueSome node -> Some node
-                        
-                    let env =
-                        match env with
-                        | ValueNone -> EnvironmentContext()
-                        | ValueSome env -> env // Only Components needs to create a new environment
 
                     let node = ViewNode(parentNode, treeContext, env, weakReference)
 
@@ -118,9 +108,9 @@ module WidgetHelpers =
         =
         let data: GroupedWidgetItems =
             { OriginalItems = items
-              HeaderTemplate = fun d -> (groupHeaderTemplate(unbox d)).Compile()
-              FooterTemplate = Some(fun d -> (groupFooterTemplate(unbox d)).Compile())
-              ItemTemplate = fun d -> (itemTemplate(unbox d)).Compile() }
+              HeaderTemplate = fun d -> groupHeaderTemplate(unbox d).Compile()
+              FooterTemplate = Some(fun d -> groupFooterTemplate(unbox d).Compile())
+              ItemTemplate = fun d -> itemTemplate(unbox d).Compile() }
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))
 
@@ -133,8 +123,8 @@ module WidgetHelpers =
         =
         let data: GroupedWidgetItems =
             { OriginalItems = items
-              HeaderTemplate = fun d -> (groupHeaderTemplate(unbox d)).Compile()
+              HeaderTemplate = fun d -> groupHeaderTemplate(unbox d).Compile()
               FooterTemplate = None
-              ItemTemplate = fun d -> (itemTemplate(unbox d)).Compile() }
+              ItemTemplate = fun d -> itemTemplate(unbox d).Compile() }
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))

--- a/src/Fabulous.MauiControls/Widgets.fs
+++ b/src/Fabulous.MauiControls/Widgets.fs
@@ -23,7 +23,7 @@ module Widgets =
               Name = typeof<'T>.Name
               TargetType = typeof<'T>
               CreateView =
-                fun (widget, treeContext, parentNode) ->
+                fun (widget, treeContext, env, parentNode) ->
                     treeContext.Logger.Debug("Creating view for {0}", typeof<'T>.Name)
 
                     let view = new 'T()
@@ -33,8 +33,13 @@ module Widgets =
                         match parentNode with
                         | ValueNone -> None
                         | ValueSome node -> Some node
+                        
+                    let env =
+                        match env with
+                        | ValueNone -> EnvironmentContext()
+                        | ValueSome env -> env // Only Components needs to create a new environment
 
-                    let node = ViewNode(parentNode, treeContext, weakReference)
+                    let node = ViewNode(parentNode, treeContext, env, weakReference)
 
                     ViewNode.set node view
 
@@ -43,7 +48,7 @@ module Widgets =
                     Reconciler.update treeContext.CanReuseView ValueNone widget node
                     struct (node :> IViewNode, box view)
               AttachView =
-                fun (widget, treeContext, parentNode, view) ->
+                fun (widget, treeContext, env, parentNode, view) ->
                     treeContext.Logger.Debug("Attaching view for {0}", typeof<'T>.Name)
 
                     let view = unbox<'T> view
@@ -53,8 +58,13 @@ module Widgets =
                         match parentNode with
                         | ValueNone -> None
                         | ValueSome node -> Some node
+                        
+                    let env =
+                        match env with
+                        | ValueNone -> EnvironmentContext()
+                        | ValueSome env -> env // Only Components needs to create a new environment
 
-                    let node = ViewNode(parentNode, treeContext, weakReference)
+                    let node = ViewNode(parentNode, treeContext, env, weakReference)
 
                     ViewNode.set node view
 


### PR DESCRIPTION
```fs
type Container =
    { ServiceA: IServiceA
      ServiceB: IServiceB }

let ContainerKey = EnvironmentKey.Create<Container>("Container")

let grandChild() =
    Component() {
        // Retrieve the environment value for the key
        let! container = Environment.Get(ContainerKey)

        Button("Click me", fun () -> container.ServiceA.DoSomething())
    }

let child() =
    Component() {
        // Note here that the environment context can skip over several layers of component
        VStack() {
            grandChild()
        }
    }

let parent (container: Container) =
    Component() {
         // Define the environment value
         do! Environment.Set(ContainerKey, container)

         child()
    }
```

It is also possible to add more environment values down the hierarchy (only accessible to descendants) and override environment values down the hierarchy as well (still only for current level and descendants).

```fs
let EnvKey1 = EnvironmentKey.Create<int>("EnvKey1")
let EnvKey2 = EnvironmentKey.Create<int>("EnvKey2")

let grandChild() =
    Component() {
        let! envValue1 = Environment.Get(EnvKey1) // Will be 20
        let! envValue2 = Environment.Get(EnvKey2) // Will be 40

        (...)
    }

let child() =
    Component() {
        let! envValue1 = Environment.Get(EnvKey1) // Will be 10
        do! Environment.Set(EnvKey1, 20)
        do! Environment.Set(EnvKey2, 40)

        VStack() {
            grandChild()
        }
    }

let parent (container: Container) =
    Component() {
         // Define the environment value
         do! Environment.Set(EnvKey1, 10)

         child()
    }
```