### PR TITLE
Avoid allocating a new ImageSource instance on each update by using specialized attributes for each value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [8.0.4] - 2024-01-08
+
+### Changed
+- Avoid allocating a new ImageSource instance on each update by using specialized attributes for each value type by @TimLariviere (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/54)
+
 ## [8.0.3] - 2024-01-03
 
 ### Fixed


### PR DESCRIPTION
While profiling an app made with Fabulous for Maui, I noticed it was spending an awful lot of time in apply diffing (~40ms on each update). I drilled down into what was taking so much time and noticed it was constantly recreating `ImageSource`s, loading the image from disk and updating the UI with it.

I found out this was because the app was using the widget signature `Image(source: string)` causing it to call `ImageSource.FromFile(source)` each time which creates a new instance of `ImageSource`.

Beyond creating reference objects over and over again which consumes memory, it also means that Fabulous thinks the images change every single time because 2 instances of ImageSource are not equal...

To avoid this issue, I created new attributes for the image source: one for each value type (string, uri, stream).

Like this, Fabulous can actually compare the value set by the user (e.g. "icon.png" = "icon.png") and update only if it's actually required.

This should shave off quite a lot of time from each single diffing in apps using images.