### PR TITLE
Additional performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes_
 
+## [8.0.5] - 2024-01-10
+
+### Changed
+- Additional performance optimizations by @TimLariviere (https://github.com/fabulous-dev/Fabulous.MauiControls/pull/55)
+
 ## [8.0.4] - 2024-01-08
 
 ### Changed
@@ -150,8 +155,9 @@ Essentially v2.8.1 and v8.0.0 are similar except for the required .NET version.
 ### Changed
 - Fabulous.MauiControls has moved from the Fabulous repository to its own repository: [https://github.com/fabulous-dev/Fabulous.MauiControls](https://github.com/fabulous-dev/Fabulous.MauiControls)
 
-[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/8.0.3...HEAD
-[8.0.3]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.3
+[unreleased]: https://github.com/fabulous-dev/Fabulous.MauiControls/compare/8.0.5...HEAD
+[8.0.5]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.5
+[8.0.4]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.4
 [8.0.2]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.2
 [8.0.1]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.1
 [8.0.0]: https://github.com/fabulous-dev/Fabulous.MauiControls/releases/tag/8.0.0

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -10,16 +10,32 @@ open System
 type AppHostBuilderExtensions =
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<unit, 'model, 'msg, #IFabApplication>) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) -> (Program.startApplication program) :> Microsoft.Maui.IApplication)
+        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
+            let app = Program.startApplication program
+            Theme.ListenForChanges(app)
+            app
+        )
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<unit, 'model, 'msg, Memo.Memoized<#IFabApplication>>) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) -> (Program.startApplicationMemo program) :> Microsoft.Maui.IApplication)
+        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
+            let app = Program.startApplicationMemo program
+            Theme.ListenForChanges(app)
+            app
+        )
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<'arg, 'model, 'msg, #IFabApplication>, arg: 'arg) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) -> (Program.startApplicationWithArgs arg program) :> Microsoft.Maui.IApplication)
+        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
+            let app = Program.startApplicationWithArgs arg program
+            Theme.ListenForChanges(app)
+            app
+        )
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<'arg, 'model, 'msg, Memo.Memoized<#IFabApplication>>, arg: 'arg) : MauiAppBuilder =
-        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) -> (Program.startApplicationWithArgsMemo arg program) :> Microsoft.Maui.IApplication)
+        this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
+            let app = Program.startApplicationWithArgsMemo arg program
+            Theme.ListenForChanges(app)
+            app
+        )

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -13,29 +13,25 @@ type AppHostBuilderExtensions =
         this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
             let app = Program.startApplication program
             Theme.ListenForChanges(app)
-            app
-        )
+            app)
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<unit, 'model, 'msg, Memo.Memoized<#IFabApplication>>) : MauiAppBuilder =
         this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
             let app = Program.startApplicationMemo program
             Theme.ListenForChanges(app)
-            app
-        )
+            app)
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<'arg, 'model, 'msg, #IFabApplication>, arg: 'arg) : MauiAppBuilder =
         this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
             let app = Program.startApplicationWithArgs arg program
             Theme.ListenForChanges(app)
-            app
-        )
+            app)
 
     [<Extension>]
     static member UseFabulousApp(this: MauiAppBuilder, program: Program<'arg, 'model, 'msg, Memo.Memoized<#IFabApplication>>, arg: 'arg) : MauiAppBuilder =
         this.UseMauiApp(fun (_serviceProvider: IServiceProvider) ->
             let app = Program.startApplicationWithArgsMemo arg program
             Theme.ListenForChanges(app)
-            app
-        )
+            app)

--- a/src/Fabulous.MauiControls/Attributes.fs
+++ b/src/Fabulous.MauiControls/Attributes.fs
@@ -5,6 +5,15 @@ open Fabulous
 open Fabulous.ScalarAttributeDefinitions
 open Microsoft.Maui.Controls
 open System
+open System.IO
+open Microsoft.Maui
+
+[<RequireQualifiedAccess>]
+type ImageSourceValue =
+    | Source of source: IImageSource
+    | File of file: string
+    | Uri of uri: Uri
+    | Stream of stream: Stream
 
 [<Struct>]
 type ValueEventData<'data, 'eventArgs> =
@@ -105,6 +114,25 @@ module Attributes =
             match newValueOpt with
             | ValueNone -> target.ClearValue(bindableProperty)
             | ValueSome v -> target.SetValue(bindableProperty, v))
+        
+    /// Performance optimization: avoid allocating a new ImageSource instance on each update
+    /// we store the user value (eg. string, Uri, Stream) and convert it to an ImageSource only when needed
+    let inline defineBindableImageSource (bindableProperty: BindableProperty) =
+        Attributes.defineScalar<ImageSourceValue, ImageSourceValue> bindableProperty.PropertyName id ScalarAttributeComparers.equalityCompare (fun _ newValueOpt node ->
+            let target = node.Target :?> BindableObject
+
+            match newValueOpt with
+            | ValueNone -> target.ClearValue(bindableProperty)
+            | ValueSome v ->
+                let value =
+                    match v with
+                    | ImageSourceValue.Source source -> source
+                    | ImageSourceValue.File file -> ImageSource.FromFile file
+                    | ImageSourceValue.Uri uri -> ImageSource.FromUri uri
+                    | ImageSourceValue.Stream stream -> ImageSource.FromStream(fun () -> stream)
+                
+                target.SetValue(bindableProperty, value)
+        )
 
     /// Define an attribute storing a Widget for a bindable property
     let inline defineBindableWidget (bindableProperty: BindableProperty) =

--- a/src/Fabulous.MauiControls/Attributes.fs
+++ b/src/Fabulous.MauiControls/Attributes.fs
@@ -114,25 +114,28 @@ module Attributes =
             match newValueOpt with
             | ValueNone -> target.ClearValue(bindableProperty)
             | ValueSome v -> target.SetValue(bindableProperty, v))
-        
+
     /// Performance optimization: avoid allocating a new ImageSource instance on each update
     /// we store the user value (eg. string, Uri, Stream) and convert it to an ImageSource only when needed
     let inline defineBindableImageSource (bindableProperty: BindableProperty) =
-        Attributes.defineScalar<ImageSourceValue, ImageSourceValue> bindableProperty.PropertyName id ScalarAttributeComparers.equalityCompare (fun _ newValueOpt node ->
-            let target = node.Target :?> BindableObject
+        Attributes.defineScalar<ImageSourceValue, ImageSourceValue>
+            bindableProperty.PropertyName
+            id
+            ScalarAttributeComparers.equalityCompare
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> BindableObject
 
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(bindableProperty)
-            | ValueSome v ->
-                let value =
-                    match v with
-                    | ImageSourceValue.Source source -> source
-                    | ImageSourceValue.File file -> ImageSource.FromFile file
-                    | ImageSourceValue.Uri uri -> ImageSource.FromUri uri
-                    | ImageSourceValue.Stream stream -> ImageSource.FromStream(fun () -> stream)
-                
-                target.SetValue(bindableProperty, value)
-        )
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(bindableProperty)
+                | ValueSome v ->
+                    let value =
+                        match v with
+                        | ImageSourceValue.Source source -> source
+                        | ImageSourceValue.File file -> ImageSource.FromFile file
+                        | ImageSourceValue.Uri uri -> ImageSource.FromUri uri
+                        | ImageSourceValue.Stream stream -> ImageSource.FromStream(fun () -> stream)
+
+                    target.SetValue(bindableProperty, value))
 
     /// Define an attribute storing a Widget for a bindable property
     let inline defineBindableWidget (bindableProperty: BindableProperty) =

--- a/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
+++ b/src/Fabulous.MauiControls/Fabulous.MauiControls.fsproj
@@ -1,6 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <UseLocalProjectReference>false</UseLocalProjectReference>    
+    
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <UseMaui>true</UseMaui>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -152,9 +154,12 @@
       This version will be used as the lower bound in the NuGet package
     -->
     <PackageReference Include="FSharp.Core" VersionOverride="8.0.100" PrivateAssets="All" />
-    <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
+    <PackageReference Include="Fabulous" Condition="'$(UseLocalProjectReference)' != 'true'" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Maui.Controls" VersionOverride="8.0.3" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" VersionOverride="8.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Condition="'$(UseLocalProjectReference)' == 'true'" Include="..\..\..\Fabulous\src\Fabulous\Fabulous.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/Fabulous.MauiControls/ThemeAware.fs
+++ b/src/Fabulous.MauiControls/ThemeAware.fs
@@ -9,18 +9,14 @@ open Fabulous.Maui
 type Theme =
     static let mutable _currentTheme = AppTheme.Unspecified
     static member Current = _currentTheme
+
     static member ListenForChanges(app: Application) =
-        app.RequestedThemeChanged.Add(fun args ->
-            _currentTheme <- args.RequestedTheme
-        )
+        app.RequestedThemeChanged.Add(fun args -> _currentTheme <- args.RequestedTheme)
 
 [<AbstractClass; Sealed>]
 type ThemeAware =
     static member With(light: 'T, dark: 'T) =
-        if Theme.Current = AppTheme.Dark then
-            dark
-        else
-            light
+        if Theme.Current = AppTheme.Dark then dark else light
 
 module ThemeAwareProgram =
     type Model<'model> = { Theme: AppTheme; Model: 'model }
@@ -32,9 +28,7 @@ module ThemeAwareProgram =
     let init (init: 'arg -> 'model * Cmd<'msg>) (arg: 'arg) =
         let model, cmd = init arg
 
-        { Theme = Theme.Current
-          Model = model },
-        Cmd.map ModelMsg cmd
+        { Theme = Theme.Current; Model = model }, Cmd.map ModelMsg cmd
 
     let update (update: 'msg * 'model -> 'model * Cmd<'msg>) (msg: Msg<'msg>, model: Model<'model>) =
         match msg with

--- a/src/Fabulous.MauiControls/ThemeAware.fs
+++ b/src/Fabulous.MauiControls/ThemeAware.fs
@@ -1,13 +1,23 @@
 namespace Fabulous.Maui
 
+open Microsoft.Maui.Controls
 open Microsoft.Maui.ApplicationModel
 open Fabulous
 open Fabulous.Maui
 
 [<AbstractClass; Sealed>]
+type Theme =
+    static let mutable _currentTheme = AppTheme.Unspecified
+    static member Current = _currentTheme
+    static member ListenForChanges(app: Application) =
+        app.RequestedThemeChanged.Add(fun args ->
+            _currentTheme <- args.RequestedTheme
+        )
+
+[<AbstractClass; Sealed>]
 type ThemeAware =
     static member With(light: 'T, dark: 'T) =
-        if AppInfo.RequestedTheme = AppTheme.Dark then
+        if Theme.Current = AppTheme.Dark then
             dark
         else
             light
@@ -22,7 +32,7 @@ module ThemeAwareProgram =
     let init (init: 'arg -> 'model * Cmd<'msg>) (arg: 'arg) =
         let model, cmd = init arg
 
-        { Theme = AppInfo.RequestedTheme
+        { Theme = Theme.Current
           Model = model },
         Cmd.map ModelMsg cmd
 

--- a/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
@@ -12,8 +12,7 @@ type IFabImageCell =
 module ImageCell =
     let WidgetKey = Widgets.register<ImageCell>()
 
-    let ImageSource =
-        Attributes.defineBindableWithEquality ImageCell.ImageSourceProperty
+    let ImageSource = Attributes.defineBindableImageSource ImageCell.ImageSourceProperty
 
 [<AutoOpen>]
 module ImageCellBuilders =
@@ -23,25 +22,25 @@ module ImageCellBuilders =
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: ImageSource) =
-            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(source))
+            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Source source))
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: string) =
-            View.ImageCell<'msg>(text, ImageSource.FromFile(source))
+            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.File source))
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: Uri) =
-            View.ImageCell<'msg>(text, ImageSource.FromUri(source))
+            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Uri source))
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: Stream) =
-            View.ImageCell<'msg>(text, ImageSource.FromStream(fun () -> source))
+            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Stream source))
 
 [<Extension>]
 type ImageCellModifiers =

--- a/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
@@ -22,13 +22,21 @@ module ImageCellBuilders =
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: ImageSource) =
-            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Source source))
+            WidgetBuilder<'msg, IFabImageCell>(
+                ImageCell.WidgetKey,
+                TextCell.Text.WithValue(text),
+                ImageCell.ImageSource.WithValue(ImageSourceValue.Source source)
+            )
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: string) =
-            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.File source))
+            WidgetBuilder<'msg, IFabImageCell>(
+                ImageCell.WidgetKey,
+                TextCell.Text.WithValue(text),
+                ImageCell.ImageSource.WithValue(ImageSourceValue.File source)
+            )
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
@@ -40,7 +48,11 @@ module ImageCellBuilders =
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
         static member inline ImageCell<'msg>(text: string, source: Stream) =
-            WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Stream source))
+            WidgetBuilder<'msg, IFabImageCell>(
+                ImageCell.WidgetKey,
+                TextCell.Text.WithValue(text),
+                ImageCell.ImageSource.WithValue(ImageSourceValue.Stream source)
+            )
 
 [<Extension>]
 type ImageCellModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/Button.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Button.fs
@@ -39,7 +39,7 @@ module Button =
         Attributes.defineBindableWithEquality<string> Button.FontFamilyProperty
 
     let FontSize = Attributes.defineBindableFloat Button.FontSizeProperty
-    
+
     let ImageSource = Attributes.defineBindableImageSource Button.ImageSourceProperty
 
     let LineBreakMode =

--- a/src/Fabulous.MauiControls/Views/Controls/Button.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Button.fs
@@ -39,9 +39,8 @@ module Button =
         Attributes.defineBindableWithEquality<string> Button.FontFamilyProperty
 
     let FontSize = Attributes.defineBindableFloat Button.FontSizeProperty
-
-    let ImageSource =
-        Attributes.defineBindableWithEquality<ImageSource> Button.ImageSourceProperty
+    
+    let ImageSource = Attributes.defineBindableImageSource Button.ImageSourceProperty
 
     let LineBreakMode =
         Attributes.defineBindableWithEquality<LineBreakMode> Button.LineBreakModeProperty
@@ -156,7 +155,7 @@ type ButtonModifiers =
     /// <param name="source">The image source</param>
     [<Extension>]
     static member inline image(this: WidgetBuilder<'msg, #IFabButton>, source: ImageSource) =
-        this.AddScalar(Button.ImageSource.WithValue(source))
+        this.AddScalar(Button.ImageSource.WithValue(ImageSourceValue.Source source))
 
     /// <summary>Set the line break mode</summary>
     /// <param name="this">Current widget</param>
@@ -211,23 +210,24 @@ type ButtonModifiers =
 type ButtonExtraModifiers =
     /// <summary>Set the image source</summary>
     /// <param name="this">Current widget</param>
-    /// <param name="source">The image source</param>
+    /// <param name="value">The image source</param>
     [<Extension>]
-    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, source: string) =
-        this.image(ImageSource.FromFile(source))
+    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, value: string) =
+        this.AddScalar(Button.ImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the image source</summary>
     /// <param name="this">Current widget</param>
-    /// <param name="source">The image source</param>
+    /// <param name="value">The image source</param>
     [<Extension>]
-    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, source: Uri) = this.image(ImageSource.FromUri(source))
+    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, value: Uri) =
+        this.AddScalar(Button.ImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the image source</summary>
     /// <param name="this">Current widget</param>
-    /// <param name="source">The image source</param>
+    /// <param name="value">The image source</param>
     [<Extension>]
-    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, source: Stream) =
-        this.image(ImageSource.FromStream(fun () -> source))
+    static member inline image(this: WidgetBuilder<'msg, #IFabButton>, value: Stream) =
+        this.AddScalar(Button.ImageSource.WithValue(ImageSourceValue.Stream value))
 
     /// <summary>Set the padding inside the button</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Controls/Image.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Image.fs
@@ -23,7 +23,7 @@ module Image =
     let IsOpaque = Attributes.defineBindableBool Image.IsOpaqueProperty
 
     let Source = Attributes.defineBindableImageSource Image.SourceProperty
-    
+
 [<AutoOpen>]
 module ImageBuilders =
     type Fabulous.Maui.View with

--- a/src/Fabulous.MauiControls/Views/Controls/Image.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Image.fs
@@ -22,25 +22,8 @@ module Image =
 
     let IsOpaque = Attributes.defineBindableBool Image.IsOpaqueProperty
 
-    let Source = Attributes.defineBindableWithEquality<ImageSource> Image.SourceProperty
-
-    /// Performance optimization: avoid allocating a new ImageSource instance on each update
-    /// we store the user value (eg. string, Uri, Stream) and convert it to an ImageSource only when needed
-    let inline private defineSourceAttribute<'model when 'model: equality> ([<InlineIfLambda>] convertModelToValue: 'model -> ImageSource) =
-        Attributes.defineScalar<'model, 'model> Image.SourceProperty.PropertyName id ScalarAttributeComparers.equalityCompare (fun _ newValueOpt node ->
-            let target = node.Target :?> Image
-
-            match newValueOpt with
-            | ValueNone -> target.ClearValue(Image.SourceProperty)
-            | ValueSome v -> target.SetValue(Image.SourceProperty, convertModelToValue v))
-
-    let SourceFile = defineSourceAttribute<string> ImageSource.FromFile
-
-    let SourceUri = defineSourceAttribute<Uri> ImageSource.FromUri
-
-    let SourceStream =
-        defineSourceAttribute<Stream>(fun stream -> ImageSource.FromStream(fun () -> stream))
-
+    let Source = Attributes.defineBindableImageSource Image.SourceProperty
+    
 [<AutoOpen>]
 module ImageBuilders =
     type Fabulous.Maui.View with
@@ -48,46 +31,46 @@ module ImageBuilders =
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
         static member inline Image<'msg>(source: ImageSource) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(source))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Source source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
         static member inline Image<'msg>(source: ImageSource, aspect: Aspect) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(source), Image.Aspect.WithValue(aspect))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Source source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
         static member inline Image<'msg>(source: string) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceFile.WithValue(source))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.File source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
         static member inline Image<'msg>(source: string, aspect: Aspect) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceFile.WithValue(source), Image.Aspect.WithValue(aspect))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.File source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
         static member inline Image<'msg>(source: Uri) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceUri.WithValue(source))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Uri source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
         static member inline Image<'msg>(source: Uri, aspect: Aspect) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceUri.WithValue(source), Image.Aspect.WithValue(aspect))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Uri source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
         static member inline Image<'msg>(source: Stream) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceStream.WithValue(source))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Stream source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
         static member inline Image<'msg>(source: Stream, aspect: Aspect) =
-            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.SourceStream.WithValue(source), Image.Aspect.WithValue(aspect))
+            WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Stream source), Image.Aspect.WithValue(aspect))
 
 [<Extension>]
 type ImageModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
@@ -41,7 +41,7 @@ module ImageButton =
     let Released =
         Attributes.defineEventNoArg "ImageButton_Released" (fun target -> (target :?> ImageButton).Released)
 
-    let Source = Attributes.defineBindableWithEquality ImageButton.SourceProperty
+    let Source = Attributes.defineBindableImageSource ImageButton.SourceProperty
 
 [<AutoOpen>]
 module ImageButtonBuilders =
@@ -54,7 +54,7 @@ module ImageButtonBuilders =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
-                ImageButton.Source.WithValue(source)
+                ImageButton.Source.WithValue(ImageSourceValue.Source source)
             )
 
         /// <summary>Create an ImageButton with an image source and an aspect and listen for the Click event</summary>
@@ -65,7 +65,7 @@ module ImageButtonBuilders =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
-                ImageButton.Source.WithValue(source),
+                ImageButton.Source.WithValue(ImageSourceValue.Source source),
                 ImageButton.Aspect.WithValue(aspect)
             )
 
@@ -73,40 +73,67 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         static member inline ImageButton<'msg>(source: string, onClicked: 'msg) =
-            View.ImageButton(ImageSource.FromFile(source), onClicked)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.File source)
+            )
 
         /// <summary>Create an ImageButton with an image source and an aspect and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
         static member inline ImageButton<'msg>(source: string, onClicked: 'msg, aspect: Aspect) =
-            View.ImageButton(ImageSource.FromFile(source), onClicked, aspect)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.File source),
+                ImageButton.Aspect.WithValue(aspect)
+            )
 
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         static member inline ImageButton<'msg>(source: Uri, onClicked: 'msg) =
-            View.ImageButton(ImageSource.FromUri(source), onClicked)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.Uri source)
+            )
 
         /// <summary>Create an ImageButton with an image source and an aspect and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
         static member inline ImageButton<'msg>(source: Uri, onClicked: 'msg, aspect: Aspect) =
-            View.ImageButton(ImageSource.FromUri(source), onClicked, aspect)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.Uri source),
+                ImageButton.Aspect.WithValue(aspect)
+            )
 
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         static member inline ImageButton<'msg>(source: Stream, onClicked: 'msg) =
-            View.ImageButton(ImageSource.FromStream(fun () -> source), onClicked)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.Stream source)
+            )
 
         /// <summary>Create an ImageButton with an image source and an aspect and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
         static member inline ImageButton<'msg>(source: Stream, onClicked: 'msg, aspect: Aspect) =
-            View.ImageButton(ImageSource.FromStream(fun () -> source), onClicked, aspect)
+            WidgetBuilder<'msg, IFabImageButton>(
+                ImageButton.WidgetKey,
+                ImageButton.Clicked.WithValue(MsgValue(onClicked)),
+                ImageButton.Source.WithValue(ImageSourceValue.Stream source),
+                ImageButton.Aspect.WithValue(aspect)
+            )
 
 [<Extension>]
 type ImageButtonModifiers =

--- a/src/Fabulous.MauiControls/Views/Controls/Slider.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Slider.fs
@@ -48,8 +48,7 @@ module Slider =
 
     let ThumbColor = Attributes.defineBindableColor Slider.ThumbColorProperty
 
-    let ThumbImageSource =
-        Attributes.defineBindableWithEquality Slider.ThumbImageSourceProperty
+    let ThumbImageSource = Attributes.defineBindableImageSource Slider.ThumbImageSourceProperty
 
     let ValueWithEvent =
         Attributes.defineBindableWithEvent "Slider_ValueWithEvent" Slider.ValueProperty (fun target -> (target :?> Slider).ValueChanged)
@@ -112,7 +111,7 @@ type SliderModifiers =
     /// <param name="value">The image source of the thumb</param>
     [<Extension>]
     static member inline thumbImage(this: WidgetBuilder<'msg, #IFabSlider>, value: ImageSource) =
-        this.AddScalar(Slider.ThumbImageSource.WithValue(value))
+        this.AddScalar(Slider.ThumbImageSource.WithValue(ImageSourceValue.Source value))
 
     /// <summary>Link a ViewRef to access the direct Slider control instance</summary>
     /// <param name="this">Current widget</param>
@@ -128,18 +127,18 @@ type SliderExtraModifiers =
     /// <param name="value">The image source of the thumb</param>
     [<Extension>]
     static member inline thumbImage(this: WidgetBuilder<'msg, #IFabSlider>, value: string) =
-        this.thumbImage(ImageSource.FromFile(value))
+        this.AddScalar(Slider.ThumbImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the image source of the thumb</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source of the thumb</param>
     [<Extension>]
     static member inline thumbImage(this: WidgetBuilder<'msg, #IFabSlider>, value: Uri) =
-        this.thumbImage(ImageSource.FromUri(value))
+        this.AddScalar(Slider.ThumbImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the image source of the thumb</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source of the thumb</param>
     [<Extension>]
     static member inline thumbImage(this: WidgetBuilder<'msg, #IFabSlider>, value: Stream) =
-        this.thumbImage(ImageSource.FromStream(fun () -> value))
+        this.AddScalar(Slider.ThumbImageSource.WithValue(ImageSourceValue.Stream value))

--- a/src/Fabulous.MauiControls/Views/Controls/Slider.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Slider.fs
@@ -48,7 +48,8 @@ module Slider =
 
     let ThumbColor = Attributes.defineBindableColor Slider.ThumbColorProperty
 
-    let ThumbImageSource = Attributes.defineBindableImageSource Slider.ThumbImageSourceProperty
+    let ThumbImageSource =
+        Attributes.defineBindableImageSource Slider.ThumbImageSourceProperty
 
     let ValueWithEvent =
         Attributes.defineBindableWithEvent "Slider_ValueWithEvent" Slider.ValueProperty (fun target -> (target :?> Slider).ValueChanged)

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
@@ -20,8 +20,7 @@ module MenuItem =
     let Clicked =
         Attributes.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> MenuItem).Clicked)
 
-    let IconImageSource =
-        Attributes.defineBindableWithEquality MenuItem.IconImageSourceProperty
+    let IconImageSource = Attributes.defineBindableImageSource MenuItem.IconImageSourceProperty
 
     let IsDestructive = Attributes.defineBindableBool MenuItem.IsDestructiveProperty
 
@@ -52,7 +51,7 @@ type MenuItemModifiers =
     /// <param name="value">The source of the icon image</param>
     [<Extension>]
     static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: ImageSource) =
-        this.AddScalar(MenuItem.IconImageSource.WithValue(value))
+        this.AddScalar(MenuItem.IconImageSource.WithValue(ImageSourceValue.Source value))
 
     /// <summary>Set a value that indicates whether or not the menu item removes its associated widget</summary>
     /// <param name="this">Current widget</param>
@@ -74,17 +73,19 @@ type MenuItemExtraModifiers =
     /// <param name="this">Current widget</param>
     /// <param name="value">The source of the icon image</param>
     [<Extension>]
-    static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: string) = this.icon(ImageSource.FromFile(value))
+    static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: string) =
+        this.AddScalar(MenuItem.IconImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the source of the icon image</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The source of the icon image</param>
     [<Extension>]
-    static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: Uri) = this.icon(ImageSource.FromUri(value))
+    static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: Uri) =
+        this.AddScalar(MenuItem.IconImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the source of the icon image</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The source of the icon image</param>
     [<Extension>]
     static member inline icon(this: WidgetBuilder<'msg, #IFabMenuItem>, value: Stream) =
-        this.icon(ImageSource.FromStream(fun () -> value))
+        this.AddScalar(MenuItem.IconImageSource.WithValue(ImageSourceValue.Stream value))

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
@@ -20,7 +20,8 @@ module MenuItem =
     let Clicked =
         Attributes.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> MenuItem).Clicked)
 
-    let IconImageSource = Attributes.defineBindableImageSource MenuItem.IconImageSourceProperty
+    let IconImageSource =
+        Attributes.defineBindableImageSource MenuItem.IconImageSourceProperty
 
     let IsDestructive = Attributes.defineBindableBool MenuItem.IsDestructiveProperty
 

--- a/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
@@ -301,8 +301,7 @@ module NavigationPageAttached =
 
     let IconColor = Attributes.defineBindableColor NavigationPage.IconColorProperty
 
-    let TitleIconImageSource =
-        Attributes.defineBindableWithEquality NavigationPage.TitleIconImageSourceProperty
+    let TitleIconImageSource = Attributes.defineBindableImageSource NavigationPage.TitleIconImageSourceProperty
 
     let TitleView = Attributes.defineBindableWidget NavigationPage.TitleViewProperty
 
@@ -428,7 +427,7 @@ type NavigationPageAttachedModifiers =
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline titleIcon(this: WidgetBuilder<'msg, #IFabPage>, value: ImageSource) =
-        this.AddScalar(NavigationPageAttached.TitleIconImageSource.WithValue(value))
+        this.AddScalar(NavigationPageAttached.TitleIconImageSource.WithValue(ImageSourceValue.Source value))
 
     /// <summary>Sets the value for TitleView</summary>
     /// <param name="this">Current widget</param>
@@ -444,21 +443,21 @@ type NavigationPageExtraAttachedModifiers =
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline titleIcon(this: WidgetBuilder<'msg, #IFabPage>, value: string) =
-        this.titleIcon(ImageSource.FromFile(value))
+        this.AddScalar(NavigationPageAttached.TitleIconImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the image source of the title icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline titleIcon(this: WidgetBuilder<'msg, #IFabPage>, value: Uri) =
-        this.titleIcon(ImageSource.FromUri(value))
+        this.AddScalar(NavigationPageAttached.TitleIconImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the image source of the title icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline titleIcon(this: WidgetBuilder<'msg, #IFabPage>, value: Stream) =
-        this.titleIcon(ImageSource.FromStream(fun () -> value))
+        this.AddScalar(NavigationPageAttached.TitleIconImageSource.WithValue(ImageSourceValue.Stream value))
 
 [<Extension>]
 type NavigationPagePlatformModifiers =

--- a/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
@@ -301,7 +301,8 @@ module NavigationPageAttached =
 
     let IconColor = Attributes.defineBindableColor NavigationPage.IconColorProperty
 
-    let TitleIconImageSource = Attributes.defineBindableImageSource NavigationPage.TitleIconImageSourceProperty
+    let TitleIconImageSource =
+        Attributes.defineBindableImageSource NavigationPage.TitleIconImageSourceProperty
 
     let TitleView = Attributes.defineBindableWidget NavigationPage.TitleViewProperty
 

--- a/src/Fabulous.MauiControls/Views/Pages/_Page.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_Page.fs
@@ -15,15 +15,13 @@ type IFabPage =
 module Page =
     let Appearing =
         Attributes.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Page).Appearing)
-
-    let BackgroundImageSource =
-        Attributes.defineBindableWithEquality Page.BackgroundImageSourceProperty
+        
+    let BackgroundImageSource = Attributes.defineBindableImageSource Page.BackgroundImageSourceProperty
 
     let Disappearing =
         Attributes.defineEventNoArg "Page_Disappearing" (fun target -> (target :?> Page).Disappearing)
 
-    let IconImageSource =
-        Attributes.defineBindableWithEquality Page.IconImageSourceProperty
+    let IconImageSource = Attributes.defineBindableImageSource Page.IconImageSourceProperty
 
     let IsBusy = Attributes.defineBindableBool Page.IsBusyProperty
 
@@ -52,14 +50,14 @@ type PageModifiers =
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline backgroundImageSource(this: WidgetBuilder<'msg, #IFabPage>, value: ImageSource) =
-        this.AddScalar(Page.BackgroundImageSource.WithValue(value))
+        this.AddScalar(Page.BackgroundImageSource.WithValue(ImageSourceValue.Source value))
 
     /// <summary>Set the image source of the icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: ImageSource) =
-        this.AddScalar(Page.IconImageSource.WithValue(value))
+        this.AddScalar(Page.IconImageSource.WithValue(ImageSourceValue.Source value))
 
     /// <summary>Set the page as busy. This will cause the global activity indicator to show a busy state</summary>
     /// <param name="this">Current widget</param>
@@ -109,40 +107,42 @@ type PageExtraModifiers =
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline backgroundImageSource(this: WidgetBuilder<'msg, #IFabPage>, value: string) =
-        this.backgroundImageSource(ImageSource.FromFile(value))
+        this.AddScalar(Page.BackgroundImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the image source of the background</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline backgroundImageSource(this: WidgetBuilder<'msg, #IFabPage>, value: Uri) =
-        this.backgroundImageSource(ImageSource.FromUri(value))
+        this.AddScalar(Page.BackgroundImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the image source of the background</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline backgroundImageSource(this: WidgetBuilder<'msg, #IFabPage>, value: Stream) =
-        this.backgroundImageSource(ImageSource.FromStream(fun () -> value))
+        this.AddScalar(Page.BackgroundImageSource.WithValue(ImageSourceValue.Stream value))
 
     /// <summary>Set the image source of the icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
-    static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: string) = this.icon(ImageSource.FromFile(value))
+    static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: string) =
+        this.AddScalar(Page.IconImageSource.WithValue(ImageSourceValue.File value))
 
     /// <summary>Set the image source of the icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
-    static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: Uri) = this.icon(ImageSource.FromUri(value))
+    static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: Uri) =
+        this.AddScalar(Page.IconImageSource.WithValue(ImageSourceValue.Uri value))
 
     /// <summary>Set the image source of the icon</summary>
     /// <param name="this">Current widget</param>
     /// <param name="value">The image source</param>
     [<Extension>]
     static member inline icon(this: WidgetBuilder<'msg, #IFabPage>, value: Stream) =
-        this.icon(ImageSource.FromStream(fun () -> value))
+        this.AddScalar(Page.IconImageSource.WithValue(ImageSourceValue.Stream value))
 
     /// <summary>Set the padding inside the widget</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.MauiControls/Views/Pages/_Page.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_Page.fs
@@ -15,13 +15,15 @@ type IFabPage =
 module Page =
     let Appearing =
         Attributes.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Page).Appearing)
-        
-    let BackgroundImageSource = Attributes.defineBindableImageSource Page.BackgroundImageSourceProperty
+
+    let BackgroundImageSource =
+        Attributes.defineBindableImageSource Page.BackgroundImageSourceProperty
 
     let Disappearing =
         Attributes.defineEventNoArg "Page_Disappearing" (fun target -> (target :?> Page).Disappearing)
 
-    let IconImageSource = Attributes.defineBindableImageSource Page.IconImageSourceProperty
+    let IconImageSource =
+        Attributes.defineBindableImageSource Page.IconImageSourceProperty
 
     let IsBusy = Attributes.defineBindableBool Page.IsBusyProperty
 


### PR DESCRIPTION
- Rewrote https://github.com/fabulous-dev/Fabulous.MauiControls/pull/54 to avoid conflicting attributes that could result in crash if user changes between image source types (eg. string -> Uri) 
- Cache `AppTheme.RequestedTheme` to speed up Fabulous apps using `ThemeAware` by avoiding querying the native platform every single time