### PR TITLE
Update Fabulous API compatibility for 3.0.0-pre23+

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="3.0.0-pre2" />
+    <PackageVersion Include="Fabulous" Version="3.0.0-pre23" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.6" />
     <PackageVersion Include="FSharp.Core" Version="8.0.200" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/src/Fabulous.MauiControls.Tests/WidgetTests.fs
+++ b/src/Fabulous.MauiControls.Tests/WidgetTests.fs
@@ -63,8 +63,9 @@ type WidgetTests() =
 
         let navPage = FabNavigationPage()
         let weakRef = WeakReference(navPage)
+        let envContext = new EnvironmentContext(treeContext.Logger)
 
-        let node = new ViewNode(None, treeContext, weakRef)
+        let node = new ViewNode(None, envContext, treeContext, weakRef)
 
         Reconciler.update treeContext.CanReuseView ValueNone (oldWidget.Compile()) node
         Reconciler.update treeContext.CanReuseView (ValueSome(oldWidget.Compile())) (newWidget.Compile()) node

--- a/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
+++ b/src/Fabulous.MauiControls/AppHostBuilderExtensions.fs
@@ -30,7 +30,8 @@ type AppHostBuilderExtensions =
                   SetComponent = Component.set }
 
             let def = WidgetDefinitionStore.get widget.Key
-            let struct (_, view) = def.CreateView(widget, treeContext, ValueNone)
+            let envContext = new EnvironmentContext(logger)
+            let struct (_, view) = def.CreateView(widget, envContext, treeContext, ValueNone)
             let app = view :?> Microsoft.Maui.Controls.Application
             Theme.ListenForChanges(app)
             app)
@@ -42,8 +43,8 @@ type AppHostBuilderExtensions =
             program.State.Logger,
             program.SyncAction,
             fun () ->
-                (View.Component(program.State, arg) {
-                    let! model = Mvu.State
+                (View.Component("_") {
+                    let! model = Context.Mvu(program.State, arg)
                     program.View model
                 })
                     .Compile()
@@ -72,5 +73,5 @@ type AppHostBuilderExtensions =
             (match syncAction with
              | Some synAction -> synAction
              | None -> MauiViewHelpers.defaultSyncAction),
-            fun () -> (View.Component() { view() }).Compile()
+            fun () -> (View.Component("_") { view() }).Compile()
         )

--- a/src/Fabulous.MauiControls/Component.fs
+++ b/src/Fabulous.MauiControls/Component.fs
@@ -17,10 +17,4 @@ module Component =
 module ComponentBuilders =
     type Fabulous.Maui.View with
 
-        static member inline Component<'msg, 'marker>() = ComponentBuilder<'msg>()
-
-        static member inline Component<'msg, 'model, 'marker, 'parentMsg>(program: Program<unit, 'model, 'msg>) =
-            MvuComponentBuilder<unit, 'msg, 'model, 'marker, 'parentMsg>(program, ())
-
-        static member inline Component<'arg, 'msg, 'model, 'marker, 'parentMsg>(program: Program<'arg, 'model, 'msg>, arg: 'arg) =
-            MvuComponentBuilder<'arg, 'msg, 'model, 'marker, 'parentMsg>(program, arg)
+        static member Component<'msg, 'marker when 'msg: equality>(key: string) = ComponentBuilder<'msg, 'marker>(key)

--- a/src/Fabulous.MauiControls/Program.fs
+++ b/src/Fabulous.MauiControls/Program.fs
@@ -8,20 +8,14 @@ open Microsoft.Maui.Controls
 
 module MauiViewHelpers =
     let private tryGetScalarValue (widget: Widget) (def: SimpleScalarAttributeDefinition<'data>) =
-        match widget.ScalarAttributes with
-        | ValueNone -> ValueNone
-        | ValueSome scalarAttrs ->
-            match Array.tryFind (fun (attr: ScalarAttribute) -> attr.Key = def.Key) scalarAttrs with
-            | None -> ValueNone
-            | Some attr -> ValueSome(unbox<'data> attr.Value)
+        match Array.tryFind (fun (attr: ScalarAttribute) -> attr.Key = def.Key) widget.ScalarAttributes with
+        | None -> ValueNone
+        | Some attr -> ValueSome(unbox<'data> attr.Value)
 
     let private tryGetWidgetCollectionValue (widget: Widget) (def: WidgetCollectionAttributeDefinition) =
-        match widget.WidgetCollectionAttributes with
-        | ValueNone -> ValueNone
-        | ValueSome collectionAttrs ->
-            match Array.tryFind (fun (attr: WidgetCollectionAttribute) -> attr.Key = def.Key) collectionAttrs with
-            | None -> ValueNone
-            | Some attr -> ValueSome attr.Value
+        match Array.tryFind (fun (attr: WidgetCollectionAttribute) -> attr.Key = def.Key) widget.WidgetCollectionAttributes with
+        | None -> ValueNone
+        | Some attr -> ValueSome attr.Value
 
     let defaultSyncAction (action: unit -> unit) =
         MainThread.BeginInvokeOnMainThread(action)

--- a/src/Fabulous.MauiControls/Style.fs
+++ b/src/Fabulous.MauiControls/Style.fs
@@ -9,7 +9,7 @@ type FabElementExtensions =
     /// <param name="this">Current widget</param>
     /// <param name="fn">The style modifier function</param>
     [<Extension>]
-    static member inline style<'msg, 'marker when 'marker :> IFabElement>
+    static member inline style<'msg, 'marker when 'msg: equality and 'marker :> IFabElement>
         (
             this: WidgetBuilder<'msg, 'marker>,
             fn: WidgetBuilder<'msg, 'marker> -> WidgetBuilder<'msg, 'marker>

--- a/src/Fabulous.MauiControls/Views/Application.fs
+++ b/src/Fabulous.MauiControls/Views/Application.fs
@@ -68,31 +68,31 @@ module Application =
             (target :?> Application).MainPage <- value)
 
     let ModalPopped =
-        Attributes.defineEvent<ModalPoppedEventArgs> "Application_ModalPopped" (fun target -> (target :?> Application).ModalPopped)
+        Attributes.Mvu.defineEvent<ModalPoppedEventArgs> "Application_ModalPopped" (fun target -> (target :?> Application).ModalPopped)
 
     let ModalPopping =
-        Attributes.defineEvent<ModalPoppingEventArgs> "Application_ModalPopping" (fun target -> (target :?> Application).ModalPopping)
+        Attributes.Mvu.defineEvent<ModalPoppingEventArgs> "Application_ModalPopping" (fun target -> (target :?> Application).ModalPopping)
 
     let ModalPushed =
-        Attributes.defineEvent<ModalPushedEventArgs> "Application_ModalPushed" (fun target -> (target :?> Application).ModalPushed)
+        Attributes.Mvu.defineEvent<ModalPushedEventArgs> "Application_ModalPushed" (fun target -> (target :?> Application).ModalPushed)
 
     let ModalPushing =
-        Attributes.defineEvent<ModalPushingEventArgs> "Application_ModalPushing" (fun target -> (target :?> Application).ModalPushing)
+        Attributes.Mvu.defineEvent<ModalPushingEventArgs> "Application_ModalPushing" (fun target -> (target :?> Application).ModalPushing)
 
     let RequestedThemeChanged =
-        Attributes.defineEvent<AppThemeChangedEventArgs> "Application_RequestedThemeChanged" (fun target -> (target :?> Application).RequestedThemeChanged)
+        Attributes.Mvu.defineEvent<AppThemeChangedEventArgs> "Application_RequestedThemeChanged" (fun target -> (target :?> Application).RequestedThemeChanged)
 
     let Resume =
-        Attributes.defineEventNoArg "Application_Resume" (fun target -> (target :?> FabApplication).Resume)
+        Attributes.Mvu.defineEventNoArg "Application_Resume" (fun target -> (target :?> FabApplication).Resume)
 
     let Sleep =
-        Attributes.defineEventNoArg "Application_Sleep" (fun target -> (target :?> FabApplication).Sleep)
+        Attributes.Mvu.defineEventNoArg "Application_Sleep" (fun target -> (target :?> FabApplication).Sleep)
 
     let Start =
-        Attributes.defineEventNoArg "Application_Start" (fun target -> (target :?> FabApplication).Start)
+        Attributes.Mvu.defineEventNoArg "Application_Start" (fun target -> (target :?> FabApplication).Start)
 
     let AppLinkRequestReceived =
-        Attributes.defineEvent "Application_AppLinkRequestReceived" (fun target -> (target :?> FabApplication).AppLinkRequestReceived)
+        Attributes.Mvu.defineEvent "Application_AppLinkRequestReceived" (fun target -> (target :?> FabApplication).AppLinkRequestReceived)
 
     let UserAppTheme =
         Attributes.defineEnum<AppTheme> "Application_UserAppTheme" (fun _ newValueOpt node ->
@@ -118,7 +118,7 @@ module ApplicationBuilders =
             WidgetHelpers.buildWidgets<'msg, IFabApplication> Application.WidgetKey [| Application.MainPage.WithValue(mainPage.Compile()) |]
 
         /// <summary>Create an Application widget with a list of windows</summary>
-        static member inline Application<'msg, 'itemMarker when 'itemMarker :> IFabWindow>() =
+        static member inline Application<'msg, 'itemMarker when 'msg: equality and 'itemMarker :> IFabWindow>() =
             CollectionBuilder<'msg, IFabApplication, 'itemMarker>(Application.WidgetKey, Application.Windows)
 
 [<Extension>]
@@ -203,7 +203,7 @@ type ApplicationModifiers =
 [<Extension>]
 type ApplicationYieldExtensions =
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'marker :> IFabApplication and 'itemType :> IFabWindow>
+    static member inline Yield<'msg, 'marker, 'itemType when 'msg: equality and 'marker :> IFabApplication and 'itemType :> IFabWindow>
         (
             _: CollectionBuilder<'msg, 'marker, IFabWindow>,
             x: WidgetBuilder<'msg, 'itemType>

--- a/src/Fabulous.MauiControls/Views/Brushes/LinearGradientBrush.fs
+++ b/src/Fabulous.MauiControls/Views/Brushes/LinearGradientBrush.fs
@@ -21,13 +21,13 @@ module LinearGradientBrushBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a LinearGradientBrush widgets that paints an area with a linear gradient, which blends two or more colors along a line known as the gradient axis</summary>
-        static member inline LinearGradientBrush<'msg>() =
+        static member inline LinearGradientBrush<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabLinearGradientBrush, IFabGradientStop>(LinearGradientBrush.WidgetKey, GradientBrush.Children)
 
         /// <summary>Create a LinearGradientBrush widgets that paints an area with a linear gradient, which blends two or more colors along a line known as the gradient axis</summary>
         /// <param name="endPoint">EndPoint, of type Point, which represents the ending two-dimensional coordinates of the linear gradient</param>
         /// <param name="startPoint">StartPoint, of type Point, which represents the starting two-dimensional coordinates of the linear gradient</param>
-        static member inline LinearGradientBrush<'msg>(startPoint: Point, endPoint: Point) =
+        static member inline LinearGradientBrush<'msg when 'msg: equality>(startPoint: Point, endPoint: Point) =
             CollectionBuilder<'msg, IFabLinearGradientBrush, IFabGradientStop>(
                 LinearGradientBrush.WidgetKey,
                 GradientBrush.Children,

--- a/src/Fabulous.MauiControls/Views/Brushes/RadialGradientBrush.fs
+++ b/src/Fabulous.MauiControls/Views/Brushes/RadialGradientBrush.fs
@@ -22,7 +22,7 @@ module RadialGradientBrushBuilders =
         /// <summary>Create a RadialGradientBrush widget that paints an area with a radial gradient, which blends two or more colors across a circle</summary>
         /// <param name="center">Center, of type Point, which represents the center point of the circle for the radial gradient</param>
         /// <param name="radius">Radius, of type float, which represents the radius of the circle for the radial gradient</param>
-        static member inline RadialGradientBrush<'msg>(center: Point, radius: float) =
+        static member inline RadialGradientBrush<'msg when 'msg: equality>(center: Point, radius: float) =
             CollectionBuilder<'msg, IFabRadialGradientBrush, IFabGradientStop>(
                 RadialGradientBrush.WidgetKey,
                 GradientBrush.Children,
@@ -31,5 +31,5 @@ module RadialGradientBrushBuilders =
             )
 
         /// <summary>Create a RadialGradientBrush widget that paints an area with a radial gradient, which blends two or more colors across a circle</summary>
-        static member inline RadialGradientBrush<'msg>() =
+        static member inline RadialGradientBrush<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabRadialGradientBrush, IFabGradientStop>(RadialGradientBrush.WidgetKey, GradientBrush.Children)

--- a/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/EntryCell.fs
@@ -47,7 +47,7 @@ module EntryCell =
     let LabelColor = Attributes.defineBindableColor EntryCell.LabelColorProperty
 
     let OnCompleted =
-        Attributes.defineEventNoArg "EntryCell_Completed" (fun target -> (target :?> EntryCell).Completed)
+        Attributes.Mvu.defineEventNoArg "EntryCell_Completed" (fun target -> (target :?> EntryCell).Completed)
 
     let Placeholder =
         Attributes.defineBindableWithEquality<string> EntryCell.PlaceholderProperty
@@ -66,7 +66,7 @@ module EntryCellBuilders =
         /// <param name="label">The label value</param>
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
-        static member inline EntryCell<'msg>(label: string, text: string, onTextChanged: string -> 'msg) =
+        static member inline EntryCell<'msg when 'msg: equality>(label: string, text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IFabEntryCell>(
                 EntryCell.WidgetKey,
                 EntryCell.Label.WithValue(label),

--- a/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/ImageCell.fs
@@ -21,7 +21,7 @@ module ImageCellBuilders =
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
-        static member inline ImageCell<'msg>(text: string, source: ImageSource) =
+        static member inline ImageCell<'msg when 'msg: equality>(text: string, source: ImageSource) =
             WidgetBuilder<'msg, IFabImageCell>(
                 ImageCell.WidgetKey,
                 TextCell.Text.WithValue(text),
@@ -31,7 +31,7 @@ module ImageCellBuilders =
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
-        static member inline ImageCell<'msg>(text: string, source: string) =
+        static member inline ImageCell<'msg when 'msg: equality>(text: string, source: string) =
             WidgetBuilder<'msg, IFabImageCell>(
                 ImageCell.WidgetKey,
                 TextCell.Text.WithValue(text),
@@ -41,13 +41,13 @@ module ImageCellBuilders =
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
-        static member inline ImageCell<'msg>(text: string, source: Uri) =
+        static member inline ImageCell<'msg when 'msg: equality>(text: string, source: Uri) =
             WidgetBuilder<'msg, IFabImageCell>(ImageCell.WidgetKey, TextCell.Text.WithValue(text), ImageCell.ImageSource.WithValue(ImageSourceValue.Uri source))
 
         /// <summary>Create an ImageCell widget with a text and an image source</summary>
         /// <param name="text">The text of the cell</param>
         /// <param name="source">The image source</param>
-        static member inline ImageCell<'msg>(text: string, source: Stream) =
+        static member inline ImageCell<'msg when 'msg: equality>(text: string, source: Stream) =
             WidgetBuilder<'msg, IFabImageCell>(
                 ImageCell.WidgetKey,
                 TextCell.Text.WithValue(text),

--- a/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/SwitchCell.fs
@@ -26,7 +26,7 @@ module SwitchCellBuilders =
         /// <param name="text">The text value</param>
         /// <param name="value">The toggle state value</param>
         /// <param name="onChanged">Change callback</param>
-        static member inline SwitchCell<'msg>(text: string, value: bool, onChanged: bool -> 'msg) =
+        static member inline SwitchCell<'msg when 'msg: equality>(text: string, value: bool, onChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabSwitchCell>(
                 SwitchCell.WidgetKey,
                 SwitchCell.OnWithEvent.WithValue(ValueEventData.create value (fun (args: ToggledEventArgs) -> onChanged args.Value)),

--- a/src/Fabulous.MauiControls/Views/Cells/TextCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/TextCell.fs
@@ -25,7 +25,7 @@ module TextCellBuilders =
 
         /// <summary>Create a TextCell widget with a text</summary>
         /// <param name="text">The text value</param>
-        static member inline TextCell<'msg>(text: string) =
+        static member inline TextCell<'msg when 'msg: equality>(text: string) =
             WidgetBuilder<'msg, IFabTextCell>(TextCell.WidgetKey, TextCell.Text.WithValue(text))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Cells/ViewCell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/ViewCell.fs
@@ -20,7 +20,7 @@ module ViewCellBuilders =
 
         /// <summary>Create a ViewCell with a content widget</summary>
         /// <param name="view">The content widget</param>
-        static member inline ViewCell<'msg, 'marker when 'marker :> IFabView>(view: WidgetBuilder<'msg, 'marker>) =
+        static member inline ViewCell<'msg, 'marker when 'msg: equality and 'marker :> IFabView>(view: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IFabViewCell> ViewCell.WidgetKey [| ViewCell.View.WithValue(view.Compile()) |]
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Cells/_Cell.fs
+++ b/src/Fabulous.MauiControls/Views/Cells/_Cell.fs
@@ -10,10 +10,10 @@ type IFabCell =
 
 module Cell =
     let Appearing =
-        Attributes.defineEventNoArg "Cell_Appearing" (fun target -> (target :?> Cell).Appearing)
+        Attributes.Mvu.defineEventNoArg "Cell_Appearing" (fun target -> (target :?> Cell).Appearing)
 
     let Disappearing =
-        Attributes.defineEventNoArg "Cell_Disappearing" (fun target -> (target :?> Cell).Disappearing)
+        Attributes.Mvu.defineEventNoArg "Cell_Disappearing" (fun target -> (target :?> Cell).Disappearing)
 
     let Height =
         Attributes.defineFloat "Cell_Height" (fun _ newValueOpt node ->
@@ -29,7 +29,7 @@ module Cell =
     let IsEnabled = Attributes.defineBindableBool Cell.IsEnabledProperty
 
     let Tapped =
-        Attributes.defineEventNoArg "Cell_Tapped" (fun target -> (target :?> Cell).Tapped)
+        Attributes.Mvu.defineEventNoArg "Cell_Tapped" (fun target -> (target :?> Cell).Tapped)
 
     let ContextActions =
         Attributes.defineListWidgetCollection "Cell_ContextActions" (fun target -> (target :?> Cell).ContextActions)
@@ -74,13 +74,13 @@ type CellModifiers =
     /// <summary>Set the context actions of the cell</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline contextActions<'msg, 'marker when 'marker :> IFabCell>(this: WidgetBuilder<'msg, 'marker>) =
+    static member inline contextActions<'msg, 'marker when 'msg: equality and 'marker :> IFabCell>(this: WidgetBuilder<'msg, 'marker>) =
         WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabMenuItem> Cell.ContextActions this
 
 [<Extension>]
 type CellYieldExtensions =
     [<Extension>]
-    static member inline Yield<'msg, 'marker, 'itemType when 'marker :> IFabCell and 'itemType :> IFabMenuItem>
+    static member inline Yield<'msg, 'marker, 'itemType when 'msg: equality and 'marker :> IFabCell and 'itemType :> IFabMenuItem>
         (
             _: AttributeCollectionBuilder<'msg, 'marker, IFabMenuItem>,
             x: WidgetBuilder<'msg, 'itemType>

--- a/src/Fabulous.MauiControls/Views/Collections/CarouselView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/CarouselView.fs
@@ -62,7 +62,7 @@ module CarouselViewBuilders =
 
         /// <summary>Create a CarouselView widget with a list of items</summary>
         /// <param name="items">The items list</param>
-        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabView>(items: seq<'itemData>) =
+        static member inline CarouselView<'msg, 'itemData, 'itemMarker when 'msg: equality and 'itemMarker :> IFabView>(items: seq<'itemData>) =
             WidgetHelpers.buildItems<'msg, IFabCarouselView, 'itemData, 'itemMarker> CarouselView.WidgetKey ItemsView.ItemsSource items
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Collections/CollectionView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/CollectionView.fs
@@ -49,7 +49,7 @@ module CollectionView =
         Attributes.defineBindableEnum<ItemSizingStrategy> CollectionView.ItemSizingStrategyProperty
 
     let SelectionChanged =
-        Attributes.defineEvent<SelectionChangedEventArgs> "CollectionView_SelectionChanged" (fun target -> (target :?> CollectionView).SelectionChanged)
+        Attributes.Mvu.defineEvent<SelectionChangedEventArgs> "CollectionView_SelectionChanged" (fun target -> (target :?> CollectionView).SelectionChanged)
 
     let SelectionMode =
         Attributes.defineBindableEnum<SelectionMode> CollectionView.SelectionModeProperty
@@ -60,13 +60,13 @@ module CollectionViewBuilders =
 
         /// <summary>Create a CollectionView widget with a list of items</summary>
         /// <param name="items">The items list</param>
-        static member inline CollectionView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabView>(items: seq<'itemData>) =
+        static member inline CollectionView<'msg, 'itemData, 'itemMarker when 'msg: equality and 'itemMarker :> IFabView>(items: seq<'itemData>) =
             WidgetHelpers.buildItems<'msg, IFabCollectionView, 'itemData, 'itemMarker> CollectionView.WidgetKey ItemsView.ItemsSource items
 
         /// <summary>Create a CollectionView widget with a list of grouped items</summary>
         /// <param name="items">The grouped items list</param>
         static member inline GroupedCollectionView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker
-            when 'itemMarker :> IFabView and 'groupMarker :> IFabView and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
+            when 'msg: equality and 'itemMarker :> IFabView and 'groupMarker :> IFabView and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
             (items: seq<'groupData>)
             =
             WidgetHelpers.buildGroupItems<'msg, IFabCollectionView, 'groupData, 'itemData, 'groupMarker, 'itemMarker>

--- a/src/Fabulous.MauiControls/Views/Collections/ListView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/ListView.fs
@@ -55,22 +55,22 @@ module ListView =
     let IsRefreshing = Attributes.defineBindableBool ListView.IsRefreshingProperty
 
     let ItemAppearing =
-        Attributes.defineEvent<ItemVisibilityEventArgs> "ListView_ItemAppearing" (fun target -> (target :?> ListView).ItemAppearing)
+        Attributes.Mvu.defineEvent<ItemVisibilityEventArgs> "ListView_ItemAppearing" (fun target -> (target :?> ListView).ItemAppearing)
 
     let ItemDisappearing =
-        Attributes.defineEvent<ItemVisibilityEventArgs> "ListView_ItemDisappearing" (fun target -> (target :?> ListView).ItemDisappearing)
+        Attributes.Mvu.defineEvent<ItemVisibilityEventArgs> "ListView_ItemDisappearing" (fun target -> (target :?> ListView).ItemDisappearing)
 
     let ItemSelected =
-        Attributes.defineEvent<SelectedItemChangedEventArgs> "ListView_ItemSelected" (fun target -> (target :?> ListView).ItemSelected)
+        Attributes.Mvu.defineEvent<SelectedItemChangedEventArgs> "ListView_ItemSelected" (fun target -> (target :?> ListView).ItemSelected)
 
     let ItemTapped =
-        Attributes.defineEvent<ItemTappedEventArgs> "ListView_ItemTapped" (fun target -> (target :?> ListView).ItemTapped)
+        Attributes.Mvu.defineEvent<ItemTappedEventArgs> "ListView_ItemTapped" (fun target -> (target :?> ListView).ItemTapped)
 
     let RefreshControlColor =
         Attributes.defineBindableColor ListView.RefreshControlColorProperty
 
     let Refreshing =
-        Attributes.defineEventNoArg "ListView_Refreshing" (fun target -> (target :?> ListView).Refreshing)
+        Attributes.Mvu.defineEventNoArg "ListView_Refreshing" (fun target -> (target :?> ListView).Refreshing)
 
     let RowHeight = Attributes.defineBindableInt ListView.RowHeightProperty
 
@@ -83,10 +83,10 @@ module ListView =
         Attributes.defineBindableEnum<SeparatorVisibility> ListView.SeparatorVisibilityProperty
 
     let Scrolled =
-        Attributes.defineEvent<ScrolledEventArgs> "ListView_Scrolled" (fun target -> (target :?> ListView).Scrolled)
+        Attributes.Mvu.defineEvent<ScrolledEventArgs> "ListView_Scrolled" (fun target -> (target :?> ListView).Scrolled)
 
     let ScrollToRequested =
-        Attributes.defineEvent<ScrollToRequestedEventArgs> "ListView_ScrollToRequested" (fun target -> (target :?> ListView).ScrollToRequested)
+        Attributes.Mvu.defineEvent<ScrollToRequestedEventArgs> "ListView_ScrollToRequested" (fun target -> (target :?> ListView).ScrollToRequested)
 
     let VerticalScrollBarVisibility =
         Attributes.defineBindableEnum<ScrollBarVisibility> ListView.VerticalScrollBarVisibilityProperty
@@ -97,13 +97,13 @@ module ListViewBuilders =
 
         /// <summary>Create a ListView with a list of items</summary>
         /// <param name="items">The items list</param>
-        static member inline ListView<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabCell>(items: seq<'itemData>) =
+        static member inline ListView<'msg, 'itemData, 'itemMarker when 'msg: equality and 'itemMarker :> IFabCell>(items: seq<'itemData>) =
             WidgetHelpers.buildItems<'msg, IFabListView, 'itemData, 'itemMarker> ListView.WidgetKey ItemsViewOfCell.ItemsSource items
 
         /// <summary>Create a ListView with a list of grouped items</summary>
         /// <param name="items">The grouped items list</param>
         static member inline GroupedListView<'msg, 'groupData, 'groupMarker, 'itemData, 'itemMarker
-            when 'itemMarker :> IFabCell and 'groupMarker :> IFabCell and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
+            when 'msg: equality and 'itemMarker :> IFabCell and 'groupMarker :> IFabCell and 'groupData :> System.Collections.Generic.IEnumerable<'itemData>>
             (items: seq<'groupData>)
             =
             WidgetHelpers.buildGroupItemsNoFooter<'msg, IFabListView, 'groupData, 'itemData, 'groupMarker, 'itemMarker>

--- a/src/Fabulous.MauiControls/Views/Collections/_ItemsView.fs
+++ b/src/Fabulous.MauiControls/Views/Collections/_ItemsView.fs
@@ -37,13 +37,13 @@ module ItemsView =
         Attributes.defineBindableInt ItemsView.RemainingItemsThresholdProperty
 
     let RemainingItemsThresholdReached =
-        Attributes.defineEventNoArg "ItemsView_RemainingItemsThresholdReached" (fun target -> (target :?> ItemsView).RemainingItemsThresholdReached)
+        Attributes.Mvu.defineEventNoArg "ItemsView_RemainingItemsThresholdReached" (fun target -> (target :?> ItemsView).RemainingItemsThresholdReached)
 
     let Scrolled =
-        Attributes.defineEvent<ItemsViewScrolledEventArgs> "ItemsView_Scrolled" (fun target -> (target :?> ItemsView).Scrolled)
+        Attributes.Mvu.defineEvent<ItemsViewScrolledEventArgs> "ItemsView_Scrolled" (fun target -> (target :?> ItemsView).Scrolled)
 
     let ScrollToRequested =
-        Attributes.defineEvent<ScrollToRequestEventArgs> "ItemsView_ScrolledRequested" (fun target -> (target :?> ItemsView).ScrollToRequested)
+        Attributes.Mvu.defineEvent<ScrollToRequestEventArgs> "ItemsView_ScrolledRequested" (fun target -> (target :?> ItemsView).ScrollToRequested)
 
     let VerticalScrollBarVisibility =
         Attributes.defineBindableEnum<ScrollBarVisibility> ItemsView.VerticalScrollBarVisibilityProperty

--- a/src/Fabulous.MauiControls/Views/Controls/ActivityIndicator.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/ActivityIndicator.fs
@@ -21,7 +21,7 @@ module ActivityIndicatorBuilders =
 
         /// <summary>Create an ActivityIndicator widget with a running state</summary>
         /// <param name="isRunning">The running state</param>
-        static member inline ActivityIndicator<'msg>(isRunning: bool) =
+        static member inline ActivityIndicator<'msg when 'msg: equality>(isRunning: bool) =
             WidgetBuilder<'msg, IFabActivityIndicator>(ActivityIndicator.WidgetKey, ActivityIndicator.IsRunning.WithValue(isRunning))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/BoxView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/BoxView.fs
@@ -21,7 +21,7 @@ module BoxViewBuilders =
 
         /// <summary>Create a BoxView widget with a color</summary>
         /// <param name="color">The color value</param>
-        static member inline BoxView<'msg>(color: Color) =
+        static member inline BoxView<'msg when 'msg: equality>(color: Color) =
             WidgetBuilder<'msg, IFabBoxView>(BoxView.WidgetKey, BoxView.Color.WithValue(color))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Button.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Button.fs
@@ -22,10 +22,10 @@ module Button =
         Attributes.defineBindableFloat Button.CharacterSpacingProperty
 
     let Clicked =
-        Attributes.defineEventNoArg "Button_Clicked" (fun target -> (target :?> Button).Clicked)
+        Attributes.Mvu.defineEventNoArg "Button_Clicked" (fun target -> (target :?> Button).Clicked)
 
     let Clicked' =
-        Attributes.defineEventNoArgNoDispatch "Button_Clicked" (fun target -> (target :?> Button).Clicked)
+        Attributes.Component.defineEventNoArg "Button_Clicked" (fun target -> (target :?> Button).Clicked)
 
     let ContentLayout =
         Attributes.defineBindableWithEquality<Button.ButtonContentLayout> Button.ContentLayoutProperty
@@ -52,10 +52,10 @@ module Button =
         Attributes.defineBindableWithEquality<Thickness> Button.PaddingProperty
 
     let Pressed =
-        Attributes.defineEventNoArg "Button_Pressed" (fun target -> (target :?> Button).Pressed)
+        Attributes.Mvu.defineEventNoArg "Button_Pressed" (fun target -> (target :?> Button).Pressed)
 
     let Released =
-        Attributes.defineEventNoArg "Button_Released" (fun target -> (target :?> Button).Released)
+        Attributes.Mvu.defineEventNoArg "Button_Released" (fun target -> (target :?> Button).Released)
 
     let Text = Attributes.defineBindableWithEquality<string> Button.TextProperty
 
@@ -71,7 +71,7 @@ module ButtonBuilders =
         /// <summary>Create a Button widget with a text and listen for the Click event</summary>
         /// <param name="text">The button on the tex</param>
         /// <param name="onClicked">Message to dispatch</param>
-        static member inline Button<'msg>(text: string, onClicked: 'msg) =
+        static member inline Button<'msg when 'msg: equality>(text: string, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabButton>(Button.WidgetKey, Button.Text.WithValue(text), Button.Clicked.WithValue(MsgValue(onClicked)))
 
         /// <summary>Create a Button widget with a text and listen for the Click event</summary>

--- a/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/CheckBox.fs
@@ -23,7 +23,7 @@ module CheckBoxBuilders =
         /// <summary>Create a CheckBox widget with a state and listen for state changes</summary>
         /// <param name="isChecked">The state of the checkbox</param>
         /// <param name="onCheckedChanged">Message to dispatch</param>
-        static member inline CheckBox<'msg>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
+        static member inline CheckBox<'msg when 'msg: equality>(isChecked: bool, onCheckedChanged: bool -> 'msg) =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
                 CheckBox.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onCheckedChanged args.Value))

--- a/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/DatePicker.fs
@@ -104,7 +104,7 @@ module DatePickerBuilders =
         /// <param name="max">The maximum date allowed</param>
         /// <param name="date">The selected date</param>
         /// <param name="onDateSelected">Message to dispatch</param>
-        static member inline DatePicker<'msg>(min: DateTime, max: DateTime, date: DateTime, onDateSelected: DateTime -> 'msg) =
+        static member inline DatePicker<'msg when 'msg: equality>(min: DateTime, max: DateTime, date: DateTime, onDateSelected: DateTime -> 'msg) =
             WidgetBuilder<'msg, IFabDatePicker>(
                 DatePicker.WidgetKey,
                 DatePicker.DateWithEvent.WithValue(

--- a/src/Fabulous.MauiControls/Views/Controls/Editor.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Editor.fs
@@ -15,7 +15,7 @@ module Editor =
         Attributes.defineBindableEnum<EditorAutoSizeOption> Editor.AutoSizeProperty
 
     let Completed =
-        Attributes.defineEventNoArg "Editor_Completed" (fun target -> (target :?> Editor).Completed)
+        Attributes.Mvu.defineEventNoArg "Editor_Completed" (fun target -> (target :?> Editor).Completed)
 
     let CursorPosition = Attributes.defineBindableInt Editor.CursorPositionProperty
 
@@ -48,7 +48,7 @@ module EditorBuilders =
         /// <summary>Create an Editor widget with a text and listen for text changes</summary>
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
-        static member inline Editor<'msg>(text: string, onTextChanged: string -> 'msg) =
+        static member inline Editor<'msg when 'msg: equality>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IFabEditor>(
                 Editor.WidgetKey,
                 InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue))

--- a/src/Fabulous.MauiControls/Views/Controls/Entry.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Entry.fs
@@ -17,7 +17,7 @@ module Entry =
         Attributes.defineBindableEnum<ClearButtonVisibility> Entry.ClearButtonVisibilityProperty
 
     let Completed =
-        Attributes.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
+        Attributes.Mvu.defineEventNoArg "Entry_Completed" (fun target -> (target :?> Entry).Completed)
 
     let CursorPosition = Attributes.defineBindableInt Entry.CursorPositionProperty
 
@@ -66,7 +66,7 @@ module EntryBuilders =
         /// <summary>Create an Entry widget with a text and listen for text changes</summary>
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
-        static member inline Entry<'msg>(text: string, onTextChanged: string -> 'msg) =
+        static member inline Entry<'msg when 'msg: equality>(text: string, onTextChanged: string -> 'msg) =
             WidgetBuilder<'msg, IFabEntry>(
                 Entry.WidgetKey,
                 InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue))

--- a/src/Fabulous.MauiControls/Views/Controls/FormattedLabel.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/FormattedLabel.fs
@@ -25,7 +25,7 @@ module FormattedLabelBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a FormattedLabel widget</summary>
-        static member inline FormattedLabel<'msg>() =
+        static member inline FormattedLabel<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabFormattedLabel, IFabSpan>(FormattedLabel.WidgetKey, FormattedLabel.Spans)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/GraphicsView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/GraphicsView.fs
@@ -12,28 +12,28 @@ module GraphicsView =
     let WidgetKey = Widgets.register<GraphicsView>()
 
     let CancelInteraction =
-        Attributes.defineEventNoArg "GraphicsView_CancelInteraction" (fun target -> (target :?> GraphicsView).CancelInteraction)
+        Attributes.Mvu.defineEventNoArg "GraphicsView_CancelInteraction" (fun target -> (target :?> GraphicsView).CancelInteraction)
 
     let DragInteraction =
-        Attributes.defineEvent<TouchEventArgs> "GraphicsView_DragInteraction" (fun target -> (target :?> GraphicsView).DragInteraction)
+        Attributes.Mvu.defineEvent<TouchEventArgs> "GraphicsView_DragInteraction" (fun target -> (target :?> GraphicsView).DragInteraction)
 
     let Drawable =
         Attributes.defineBindableWithEquality<IDrawable> GraphicsView.DrawableProperty
 
     let EndHoverInteraction =
-        Attributes.defineEventNoArg "GraphicsView_EndHoverInteraction" (fun target -> (target :?> GraphicsView).EndHoverInteraction)
+        Attributes.Mvu.defineEventNoArg "GraphicsView_EndHoverInteraction" (fun target -> (target :?> GraphicsView).EndHoverInteraction)
 
     let EndInteraction =
-        Attributes.defineEvent<TouchEventArgs> "GraphicsView_EndInteraction" (fun target -> (target :?> GraphicsView).EndInteraction)
+        Attributes.Mvu.defineEvent<TouchEventArgs> "GraphicsView_EndInteraction" (fun target -> (target :?> GraphicsView).EndInteraction)
 
     let MoveHoverInteraction =
-        Attributes.defineEvent<TouchEventArgs> "GraphicsView_MoveHoverInteraction" (fun target -> (target :?> GraphicsView).MoveHoverInteraction)
+        Attributes.Mvu.defineEvent<TouchEventArgs> "GraphicsView_MoveHoverInteraction" (fun target -> (target :?> GraphicsView).MoveHoverInteraction)
 
     let StartHoverInteraction =
-        Attributes.defineEvent<TouchEventArgs> "GraphicsView_StartHoverInteraction" (fun target -> (target :?> GraphicsView).StartHoverInteraction)
+        Attributes.Mvu.defineEvent<TouchEventArgs> "GraphicsView_StartHoverInteraction" (fun target -> (target :?> GraphicsView).StartHoverInteraction)
 
     let StartInteraction =
-        Attributes.defineEvent<TouchEventArgs> "GraphicsView_StartInteraction" (fun target -> (target :?> GraphicsView).StartInteraction)
+        Attributes.Mvu.defineEvent<TouchEventArgs> "GraphicsView_StartInteraction" (fun target -> (target :?> GraphicsView).StartInteraction)
 
 [<AutoOpen>]
 module GraphicsViewBuilders =
@@ -42,7 +42,7 @@ module GraphicsViewBuilders =
 
         /// <summary>Create a GraphicsView widget with a drawable content</summary>
         /// <param name="drawable">The drawable content</param>
-        static member inline GraphicsView<'msg>(drawable: IDrawable) =
+        static member inline GraphicsView<'msg when 'msg: equality>(drawable: IDrawable) =
             WidgetBuilder<'msg, IGraphicsView>(GraphicsView.WidgetKey, GraphicsView.Drawable.WithValue(drawable))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Image.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Image.fs
@@ -30,46 +30,46 @@ module ImageBuilders =
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
-        static member inline Image<'msg>(source: ImageSource) =
+        static member inline Image<'msg when 'msg: equality>(source: ImageSource) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Source source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
-        static member inline Image<'msg>(source: ImageSource, aspect: Aspect) =
+        static member inline Image<'msg when 'msg: equality>(source: ImageSource, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Source source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
-        static member inline Image<'msg>(source: string) =
+        static member inline Image<'msg when 'msg: equality>(source: string) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.File source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
-        static member inline Image<'msg>(source: string, aspect: Aspect) =
+        static member inline Image<'msg when 'msg: equality>(source: string, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.File source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
-        static member inline Image<'msg>(source: Uri) =
+        static member inline Image<'msg when 'msg: equality>(source: Uri) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Uri source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
-        static member inline Image<'msg>(source: Uri, aspect: Aspect) =
+        static member inline Image<'msg when 'msg: equality>(source: Uri, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Uri source), Image.Aspect.WithValue(aspect))
 
         /// <summary>Create an Image widget with a source</summary>
         /// <param name="source">The image source</param>
-        static member inline Image<'msg>(source: Stream) =
+        static member inline Image<'msg when 'msg: equality>(source: Stream) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Stream source))
 
         /// <summary>Create an Image widget with a source and an aspect</summary>
         /// <param name="source">The image source</param>
         /// <param name="aspect">The image aspect</param>
-        static member inline Image<'msg>(source: Stream, aspect: Aspect) =
+        static member inline Image<'msg when 'msg: equality>(source: Stream, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImage>(Image.WidgetKey, Image.Source.WithValue(ImageSourceValue.Stream source), Image.Aspect.WithValue(aspect))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/ImageButton.fs
@@ -22,7 +22,7 @@ module ImageButton =
     let BorderWidth = Attributes.defineBindableFloat ImageButton.BorderWidthProperty
 
     let Clicked =
-        Attributes.defineEventNoArg "ImageButton_Clicked" (fun target -> (target :?> ImageButton).Clicked)
+        Attributes.Mvu.defineEventNoArg "ImageButton_Clicked" (fun target -> (target :?> ImageButton).Clicked)
 
     let CornerRadius = Attributes.defineBindableFloat ImageButton.CornerRadiusProperty
 
@@ -36,10 +36,10 @@ module ImageButton =
         Attributes.defineBindableWithEquality<Thickness> ImageButton.PaddingProperty
 
     let Pressed =
-        Attributes.defineEventNoArg "ImageButton_Pressed" (fun target -> (target :?> ImageButton).Pressed)
+        Attributes.Mvu.defineEventNoArg "ImageButton_Pressed" (fun target -> (target :?> ImageButton).Pressed)
 
     let Released =
-        Attributes.defineEventNoArg "ImageButton_Released" (fun target -> (target :?> ImageButton).Released)
+        Attributes.Mvu.defineEventNoArg "ImageButton_Released" (fun target -> (target :?> ImageButton).Released)
 
     let Source = Attributes.defineBindableImageSource ImageButton.SourceProperty
 
@@ -50,7 +50,7 @@ module ImageButtonBuilders =
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
-        static member inline ImageButton<'msg>(source: ImageSource, onClicked: 'msg) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: ImageSource, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -61,7 +61,7 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
-        static member inline ImageButton<'msg>(source: ImageSource, onClicked: 'msg, aspect: Aspect) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: ImageSource, onClicked: 'msg, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -72,7 +72,7 @@ module ImageButtonBuilders =
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
-        static member inline ImageButton<'msg>(source: string, onClicked: 'msg) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: string, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -83,7 +83,7 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
-        static member inline ImageButton<'msg>(source: string, onClicked: 'msg, aspect: Aspect) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: string, onClicked: 'msg, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -94,7 +94,7 @@ module ImageButtonBuilders =
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
-        static member inline ImageButton<'msg>(source: Uri, onClicked: 'msg) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: Uri, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -105,7 +105,7 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
-        static member inline ImageButton<'msg>(source: Uri, onClicked: 'msg, aspect: Aspect) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: Uri, onClicked: 'msg, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -116,7 +116,7 @@ module ImageButtonBuilders =
         /// <summary>Create an ImageButton with an image source and listen for the Click event</summary>
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
-        static member inline ImageButton<'msg>(source: Stream, onClicked: 'msg) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: Stream, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),
@@ -127,7 +127,7 @@ module ImageButtonBuilders =
         /// <param name="source">The image source</param>
         /// <param name="onClicked">Message to dispatch</param>
         /// <param name="aspect">The aspect value</param>
-        static member inline ImageButton<'msg>(source: Stream, onClicked: 'msg, aspect: Aspect) =
+        static member inline ImageButton<'msg when 'msg: equality>(source: Stream, onClicked: 'msg, aspect: Aspect) =
             WidgetBuilder<'msg, IFabImageButton>(
                 ImageButton.WidgetKey,
                 ImageButton.Clicked.WithValue(MsgValue(onClicked)),

--- a/src/Fabulous.MauiControls/Views/Controls/IndicatorView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/IndicatorView.fs
@@ -43,7 +43,7 @@ module IndicatorViewBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create an IndicatorView widget with a reference</summary>
-        static member inline IndicatorView<'msg>(reference: ViewRef<IndicatorView>) =
+        static member inline IndicatorView<'msg when 'msg: equality>(reference: ViewRef<IndicatorView>) =
             WidgetBuilder<'msg, IFabIndicatorView>(IndicatorView.WidgetKey, ViewRefAttributes.ViewRef.WithValue(reference.Unbox))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Label.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Label.fs
@@ -58,7 +58,7 @@ module LabelBuilders =
 
         /// <summary>Create a Label widget with a text</summary>
         /// <param name="text">The text value</param>
-        static member inline Label<'msg>(text: string) =
+        static member inline Label<'msg when 'msg: equality>(text: string) =
             WidgetBuilder<'msg, IFabLabel>(Label.WidgetKey, Label.Text.WithValue(text))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Controls/Picker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Picker.fs
@@ -100,7 +100,7 @@ module PickerBuilders =
         /// <param name="items">The items list</param>
         /// <param name="selectedIndex">The selected index</param>
         /// <param name="onSelectedIndexChanged">Message to dispatch</param>
-        static member inline Picker<'msg>(items: string list, selectedIndex: int, onSelectedIndexChanged: int -> 'msg) =
+        static member inline Picker<'msg when 'msg: equality>(items: string list, selectedIndex: int, onSelectedIndexChanged: int -> 'msg) =
             WidgetBuilder<'msg, IFabPicker>(
                 Picker.WidgetKey,
                 Picker.ItemsSource.WithValue(Array.ofList items),

--- a/src/Fabulous.MauiControls/Views/Controls/ProgressBar.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/ProgressBar.fs
@@ -38,14 +38,14 @@ module ProgressBarBuilders =
 
         /// <summary>Create a ProgressBar widget with a current progress value</summary>
         /// <param name="progress">The progress value</param>
-        static member inline ProgressBar<'msg>(progress: float) =
+        static member inline ProgressBar<'msg when 'msg: equality>(progress: float) =
             WidgetBuilder<'msg, IFabProgressBar>(ProgressBar.WidgetKey, ProgressBar.Progress.WithValue(progress))
 
         /// <summary>Create a ProgressBar widget with a progress value that will animate when changed</summary>
         /// <param name="progress">The progress value</param>
         /// <param name="duration">The duration of the animation</param>
         /// <param name="easing">The easing of the animation</param>
-        static member inline ProgressBar<'msg>(progress: float, duration: int, easing: Easing) =
+        static member inline ProgressBar<'msg when 'msg: equality>(progress: float, duration: int, easing: Easing) =
             WidgetBuilder<'msg, IFabProgressBar>(
                 ProgressBar.WidgetKey,
                 ProgressBarAnimations.ProgressTo.WithValue(

--- a/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/RadioButton.fs
@@ -61,7 +61,7 @@ module RadioButtonBuilders =
         /// <param name="content">The content</param>
         /// <param name="isChecked">The checked state</param>
         /// <param name="onChecked">Message to dispatch</param>
-        static member inline RadioButton<'msg>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
+        static member inline RadioButton<'msg when 'msg: equality>(content: string, isChecked: bool, onChecked: bool -> 'msg) =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
                 RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onChecked args.Value)),
@@ -79,8 +79,9 @@ module RadioButtonBuilders =
                     StackList.one(
                         RadioButton.IsCheckedWithEvent.WithValue(ValueEventData.create isChecked (fun (args: CheckedChangedEventArgs) -> onChecked args.Value))
                     ),
-                    ValueSome [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
-                    ValueNone
+                    [| RadioButton.ContentWidget.WithValue(content.Compile()) |],
+                    [||],
+                    [||]
                 )
             )
 

--- a/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/SearchBar.fs
@@ -35,7 +35,7 @@ module SearchBar =
         Attributes.defineBindableBool SearchBar.IsTextPredictionEnabledProperty
 
     let SearchButtonPressed =
-        Attributes.defineEventNoArg "SearchBar_SearchButtonPressed" (fun target -> (target :?> SearchBar).SearchButtonPressed)
+        Attributes.Mvu.defineEventNoArg "SearchBar_SearchButtonPressed" (fun target -> (target :?> SearchBar).SearchButtonPressed)
 
     let SelectionLength = Attributes.defineBindableInt SearchBar.SelectionLengthProperty
 
@@ -50,7 +50,7 @@ module SearchBarBuilders =
         /// <param name="text">The text value</param>
         /// <param name="onTextChanged">Message to dispatch</param>
         /// <param name="onSearchButtonPressed">Message to dispatch</param>
-        static member inline SearchBar<'msg>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
+        static member inline SearchBar<'msg when 'msg: equality>(text: string, onTextChanged: string -> 'msg, onSearchButtonPressed: 'msg) =
             WidgetBuilder<'msg, IFabSearchBar>(
                 SearchBar.WidgetKey,
                 InputView.TextWithEvent.WithValue(ValueEventData.create text (fun (args: TextChangedEventArgs) -> onTextChanged args.NewTextValue)),

--- a/src/Fabulous.MauiControls/Views/Controls/Slider.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Slider.fs
@@ -32,10 +32,10 @@ module Slider =
     let WidgetKey = Widgets.register<Slider>()
 
     let DragCompleted =
-        Attributes.defineEventNoArg "Slider_DragCompleted" (fun target -> (target :?> Slider).DragCompleted)
+        Attributes.Mvu.defineEventNoArg "Slider_DragCompleted" (fun target -> (target :?> Slider).DragCompleted)
 
     let DragStarted =
-        Attributes.defineEventNoArg "Slider_DragStarted" (fun target -> (target :?> Slider).DragStarted)
+        Attributes.Mvu.defineEventNoArg "Slider_DragStarted" (fun target -> (target :?> Slider).DragStarted)
 
     let MaximumTrackColor =
         Attributes.defineBindableColor Slider.MaximumTrackColorProperty
@@ -63,7 +63,7 @@ module SliderBuilders =
         /// <param name="max">The maximum bound</param>
         /// <param name="value">The current value</param>
         /// <param name="onValueChanged">Message to dispatch</param>
-        static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
+        static member inline Slider<'msg when 'msg: equality>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, IFabSlider>(
                 Slider.WidgetKey,
                 Slider.MinimumMaximum.WithValue(struct (min, max)),

--- a/src/Fabulous.MauiControls/Views/Controls/Span.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Span.fs
@@ -49,7 +49,7 @@ module SpanBuilders =
 
         /// <summary>Create a Span widget with a text</summary>
         /// <param name="text">The text value</param>
-        static member inline Span<'msg>(text: string) =
+        static member inline Span<'msg when 'msg: equality>(text: string) =
             WidgetBuilder<'msg, IFabSpan>(Span.WidgetKey, Span.Text.WithValue(text))
 
 [<Extension>]
@@ -100,7 +100,7 @@ type SpanModifiers =
     /// <summary>Set the gesture recognizers</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline gestureRecognizers<'msg, 'marker when 'marker :> IFabSpan>(this: WidgetBuilder<'msg, 'marker>) =
+    static member inline gestureRecognizers<'msg, 'marker when 'msg: equality and 'marker :> IFabSpan>(this: WidgetBuilder<'msg, 'marker>) =
         WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabGestureRecognizer> Span.GestureRecognizers this
 
     /// <summary>Set the line height</summary>

--- a/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Stepper.fs
@@ -45,7 +45,7 @@ module StepperBuilders =
         /// <param name="max">The maximum value</param>
         /// <param name="value">The current value</param>
         /// <param name="onValueChanged">Message to dispatch</param>
-        static member inline Stepper<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
+        static member inline Stepper<'msg when 'msg: equality>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
             WidgetBuilder<'msg, IFabStepper>(
                 Stepper.WidgetKey,
                 Stepper.MinimumMaximum.WithValue(struct (min, max)),

--- a/src/Fabulous.MauiControls/Views/Controls/Switch.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/Switch.fs
@@ -25,7 +25,7 @@ module SwitchBuilders =
         /// <summary>Create a Switch widget with a toggle state and listen for toggle state changes</summary>
         /// <param name="isToggled">The toggle state</param>
         /// <param name="onToggled">Message to dispatch</param>
-        static member inline Switch<'msg>(isToggled: bool, onToggled: bool -> 'msg) =
+        static member inline Switch<'msg when 'msg: equality>(isToggled: bool, onToggled: bool -> 'msg) =
             WidgetBuilder<'msg, IFabSwitch>(
                 Switch.WidgetKey,
                 Switch.IsToggledWithEvent.WithValue(ValueEventData.create isToggled (fun (args: ToggledEventArgs) -> onToggled args.Value))

--- a/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/TimePicker.fs
@@ -72,7 +72,7 @@ module TimePickerBuilders =
         /// <summary>Create a TimePicker widget with a selected time and listen for the selected time changes</summary>
         /// <param name="time">The selected time</param>
         /// <param name="onTimeSelected">Message to dispatch</param>
-        static member inline TimePicker<'msg>(time: TimeSpan, onTimeSelected: TimeSpan -> 'msg) =
+        static member inline TimePicker<'msg when 'msg: equality>(time: TimeSpan, onTimeSelected: TimeSpan -> 'msg) =
             WidgetBuilder<'msg, IFabTimePicker>(
                 TimePicker.WidgetKey,
                 TimePicker.TimeWithEvent.WithValue(ValueEventData.create time (fun (args: TimeSelectedEventArgs) -> onTimeSelected args.NewTime))

--- a/src/Fabulous.MauiControls/Views/Controls/WebView.fs
+++ b/src/Fabulous.MauiControls/Views/Controls/WebView.fs
@@ -21,10 +21,10 @@ module WebView =
         Attributes.defineBindableWithEquality<CookieContainer> WebView.CookiesProperty
 
     let Navigated =
-        Attributes.defineEvent<WebNavigatedEventArgs> "WebView_Navigated" (fun target -> (target :?> WebView).Navigated)
+        Attributes.Mvu.defineEvent<WebNavigatedEventArgs> "WebView_Navigated" (fun target -> (target :?> WebView).Navigated)
 
     let Navigating =
-        Attributes.defineEvent<WebNavigatingEventArgs> "WebView_Navigating" (fun target -> (target :?> WebView).Navigating)
+        Attributes.Mvu.defineEvent<WebNavigatingEventArgs> "WebView_Navigating" (fun target -> (target :?> WebView).Navigating)
 
     let Source =
         Attributes.defineBindableWithEquality<WebViewSource> WebView.SourceProperty
@@ -58,13 +58,13 @@ module WebViewBuilders =
 
         /// <summary>Create a WebView with a source</summary>
         /// <param name="source">The web source</param>
-        static member inline WebView<'msg>(source: WebViewSource) =
+        static member inline WebView<'msg when 'msg: equality>(source: WebViewSource) =
             WidgetBuilder<'msg, IFabWebView>(WebView.WidgetKey, WebView.Source.WithValue(source))
 
         /// <summary>Create a WebView with an HTML content</summary>
         /// <param name="html">The HTML content</param>
         /// <param name="baseUrl">The base URL</param>
-        static member inline WebView<'msg>(html: string, ?baseUrl: string) =
+        static member inline WebView<'msg when 'msg: equality>(html: string, ?baseUrl: string) =
             let source =
                 match baseUrl with
                 | Some url -> HtmlWebViewSource(Html = html, BaseUrl = url)
@@ -74,12 +74,12 @@ module WebViewBuilders =
 
         /// <summary>Create a WebView with a Uri source</summary>
         /// <param name="uri">The Uri source</param>
-        static member inline WebView<'msg>(uri: Uri) =
+        static member inline WebView<'msg when 'msg: equality>(uri: Uri) =
             View.WebView<'msg>(WebViewSource.op_Implicit uri)
 
         /// <summary>Create a WebView with a Url source</summary>
         /// <param name="url">The Url source</param>
-        static member inline WebView<'msg>(url: string) =
+        static member inline WebView<'msg when 'msg: equality>(url: string) =
             View.WebView<'msg>(WebViewSource.op_Implicit url)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/DragGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/DragGestureRecognizer.fs
@@ -13,10 +13,10 @@ module DragGestureRecognizer =
     let CanDrag = Attributes.defineBindableBool DragGestureRecognizer.CanDragProperty
 
     let DragStarting =
-        Attributes.defineEvent<DragStartingEventArgs> "DragGestureRecognizer_DragStarting" (fun target -> (target :?> DragGestureRecognizer).DragStarting)
+        Attributes.Mvu.defineEvent<DragStartingEventArgs> "DragGestureRecognizer_DragStarting" (fun target -> (target :?> DragGestureRecognizer).DragStarting)
 
     let DropCompleted =
-        Attributes.defineEvent<DropCompletedEventArgs> "DragGestureRecognizer_DropCompleted" (fun target -> (target :?> DragGestureRecognizer).DropCompleted)
+        Attributes.Mvu.defineEvent<DropCompletedEventArgs> "DragGestureRecognizer_DropCompleted" (fun target -> (target :?> DragGestureRecognizer).DropCompleted)
 
 [<AutoOpen>]
 module DragGestureRecognizerBuilders =
@@ -24,7 +24,7 @@ module DragGestureRecognizerBuilders =
 
         /// <summary>Create a DragGestureRecognizer that listens for DragStarting event</summary>
         /// <param name="onDragStarting">Message to dispatch</param>
-        static member inline DragGestureRecognizer<'msg>(onDragStarting: DragStartingEventArgs -> 'msg) =
+        static member inline DragGestureRecognizer<'msg when 'msg: equality>(onDragStarting: DragStartingEventArgs -> 'msg) =
             WidgetBuilder<'msg, IFabDragGestureRecognizer>(
                 DragGestureRecognizer.WidgetKey,
                 DragGestureRecognizer.DragStarting.WithValue(fun args -> onDragStarting args |> box)

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/DropGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/DropGestureRecognizer.fs
@@ -14,13 +14,13 @@ module DropGestureRecognizer =
         Attributes.defineBindableBool DropGestureRecognizer.AllowDropProperty
 
     let Drop =
-        Attributes.defineEvent<DropEventArgs> "DropGestureRecognizer_Drop" (fun target -> (target :?> DropGestureRecognizer).Drop)
+        Attributes.Mvu.defineEvent<DropEventArgs> "DropGestureRecognizer_Drop" (fun target -> (target :?> DropGestureRecognizer).Drop)
 
     let DragOver =
-        Attributes.defineEvent<DragEventArgs> "DropGestureRecognizer_DragOver" (fun target -> (target :?> DropGestureRecognizer).DragOver)
+        Attributes.Mvu.defineEvent<DragEventArgs> "DropGestureRecognizer_DragOver" (fun target -> (target :?> DropGestureRecognizer).DragOver)
 
     let DragLeave =
-        Attributes.defineEvent<DragEventArgs> "DropGestureRecognizer_DragLeave" (fun target -> (target :?> DropGestureRecognizer).DragLeave)
+        Attributes.Mvu.defineEvent<DragEventArgs> "DropGestureRecognizer_DragLeave" (fun target -> (target :?> DropGestureRecognizer).DragLeave)
 
 [<AutoOpen>]
 module DropGestureRecognizerBuilders =
@@ -28,7 +28,7 @@ module DropGestureRecognizerBuilders =
 
         /// <summary>Create a DropGestureRecognizer that listens for Drop event</summary>
         /// <param name="onDrop">Message to dispatch</param>
-        static member inline DropGestureRecognizer<'msg>(onDrop: DropEventArgs -> 'msg) =
+        static member inline DropGestureRecognizer<'msg when 'msg: equality>(onDrop: DropEventArgs -> 'msg) =
             WidgetBuilder<'msg, IFabDropGestureRecognizer>(
                 DropGestureRecognizer.WidgetKey,
                 DropGestureRecognizer.Drop.WithValue(fun args -> onDrop args |> box)

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/PanGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/PanGestureRecognizer.fs
@@ -11,7 +11,7 @@ module PanGestureRecognizer =
     let WidgetKey = Widgets.register<PanGestureRecognizer>()
 
     let PanUpdated =
-        Attributes.defineEvent<PanUpdatedEventArgs> "PanGestureRecognizer_PanUpdated" (fun target -> (target :?> PanGestureRecognizer).PanUpdated)
+        Attributes.Mvu.defineEvent<PanUpdatedEventArgs> "PanGestureRecognizer_PanUpdated" (fun target -> (target :?> PanGestureRecognizer).PanUpdated)
 
     let TouchPoints =
         Attributes.defineBindableInt PanGestureRecognizer.TouchPointsProperty
@@ -22,7 +22,7 @@ module PanGestureRecognizerBuilders =
 
         /// <summary>Create a PanGestureRecognizer that listens for Pan event</summary>
         /// <param name="onPanUpdated">Message to dispatch</param>
-        static member inline PanGestureRecognizer<'msg>(onPanUpdated: PanUpdatedEventArgs -> 'msg) =
+        static member inline PanGestureRecognizer<'msg when 'msg: equality>(onPanUpdated: PanUpdatedEventArgs -> 'msg) =
             WidgetBuilder<'msg, IFabPanGestureRecognizer>(
                 PanGestureRecognizer.WidgetKey,
                 PanGestureRecognizer.PanUpdated.WithValue(fun args -> onPanUpdated args |> box)

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/PinchGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/PinchGestureRecognizer.fs
@@ -11,7 +11,7 @@ module PinchGestureRecognizer =
     let WidgetKey = Widgets.register<PinchGestureRecognizer>()
 
     let PinchUpdated =
-        Attributes.defineEvent<PinchGestureUpdatedEventArgs> "PinchGestureRecognizer_PinchUpdated" (fun target ->
+        Attributes.Mvu.defineEvent<PinchGestureUpdatedEventArgs> "PinchGestureRecognizer_PinchUpdated" (fun target ->
             (target :?> PinchGestureRecognizer).PinchUpdated)
 
 [<AutoOpen>]
@@ -20,7 +20,7 @@ module PinchGestureRecognizerBuilders =
 
         /// <summary>Create a PinchGestureRecognizer that listens for Pinch event</summary>
         /// <param name="onPinchUpdated">Message to dispatch</param>
-        static member inline PinchGestureRecognizer<'msg>(onPinchUpdated: PinchGestureUpdatedEventArgs -> 'msg) =
+        static member inline PinchGestureRecognizer<'msg when 'msg: equality>(onPinchUpdated: PinchGestureUpdatedEventArgs -> 'msg) =
             WidgetBuilder<'msg, IFabPinchGestureRecognizer>(
                 PinchGestureRecognizer.WidgetKey,
                 PinchGestureRecognizer.PinchUpdated.WithValue(fun args -> onPinchUpdated args |> box)

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/SwipeGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/SwipeGestureRecognizer.fs
@@ -15,7 +15,7 @@ module SwipeGestureRecognizer =
         Attributes.defineBindableEnum<SwipeDirection> SwipeGestureRecognizer.DirectionProperty
 
     let Swiped =
-        Attributes.defineEvent<SwipedEventArgs> "SwipeGestureRecognizer_Swiped" (fun target -> (target :?> SwipeGestureRecognizer).Swiped)
+        Attributes.Mvu.defineEvent<SwipedEventArgs> "SwipeGestureRecognizer_Swiped" (fun target -> (target :?> SwipeGestureRecognizer).Swiped)
 
     let Threshold =
         Attributes.defineBindableInt SwipeGestureRecognizer.ThresholdProperty
@@ -26,7 +26,7 @@ module SwipeGestureRecognizerBuilders =
 
         /// <summary>Create a SwipeGestureRecognizer that listens for Swipe event</summary>
         /// <param name="onSwiped">Message to dispatch</param>
-        static member inline SwipeGestureRecognizer<'msg>(onSwiped: SwipeDirection -> 'msg) =
+        static member inline SwipeGestureRecognizer<'msg when 'msg: equality>(onSwiped: SwipeDirection -> 'msg) =
             WidgetBuilder<'msg, IFabSwipeGestureRecognizer>(
                 SwipeGestureRecognizer.WidgetKey,
                 SwipeGestureRecognizer.Swiped.WithValue(fun args -> onSwiped args.Direction |> box)

--- a/src/Fabulous.MauiControls/Views/GestureRecognizers/TapGestureRecognizer.fs
+++ b/src/Fabulous.MauiControls/Views/GestureRecognizers/TapGestureRecognizer.fs
@@ -14,7 +14,7 @@ module TapGestureRecognizer =
         Attributes.defineBindableInt TapGestureRecognizer.NumberOfTapsRequiredProperty
 
     let Tapped =
-        Attributes.defineEvent "TapGestureRecognizer_Tapped" (fun target -> (target :?> TapGestureRecognizer).Tapped)
+        Attributes.Mvu.defineEvent "TapGestureRecognizer_Tapped" (fun target -> (target :?> TapGestureRecognizer).Tapped)
 
 [<AutoOpen>]
 module TapGestureRecognizerBuilders =
@@ -22,7 +22,7 @@ module TapGestureRecognizerBuilders =
 
         /// <summary>Create a TapGestureRecognizer that listens for Tapped event</summary>
         /// <param name="onTapped">Message to dispatch</param>
-        static member inline TapGestureRecognizer<'msg>(onTapped: 'msg) =
+        static member inline TapGestureRecognizer<'msg when 'msg: equality>(onTapped: 'msg) =
             WidgetBuilder<'msg, IFabTapGestureRecognizer>(TapGestureRecognizer.WidgetKey, TapGestureRecognizer.Tapped.WithValue(fun _ -> box onTapped))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/KeyboardAccelerator.fs
+++ b/src/Fabulous.MauiControls/Views/KeyboardAccelerator.fs
@@ -23,13 +23,13 @@ module KeyboardAcceleratorBuilders =
 
         /// <summary>Create a KeyboardAccelerator widget with a key</summary>
         /// <param name="key">The key triggering the accelerator</param>
-        static member inline KeyboardAccelerator<'msg>(key: string) =
+        static member inline KeyboardAccelerator<'msg when 'msg: equality>(key: string) =
             WidgetBuilder<'msg, IFabKeyboardAccelerator>(KeyboardAccelerator.WidgetKey, KeyboardAccelerator.Key.WithValue(key))
 
         /// <summary>Create a KeyboardAccelerator widget with a key and a modifier</summary>
         /// <param name="key">The key triggering the accelerator</param>
         /// <param name="modifiers">The modifiers required to trigger the accelerator</param>
-        static member inline KeyboardAccelerator<'msg>(key: string, modifiers: KeyboardAcceleratorModifiers) =
+        static member inline KeyboardAccelerator<'msg when 'msg: equality>(key: string, modifiers: KeyboardAcceleratorModifiers) =
             WidgetBuilder<'msg, IFabKeyboardAccelerator>(
                 KeyboardAccelerator.WidgetKey,
                 KeyboardAccelerator.Key.WithValue(key),

--- a/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/AbsoluteLayout.fs
@@ -23,7 +23,7 @@ module AbsoluteLayoutBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create an AbsoluteLayout widget</summary>
-        static member inline AbsoluteLayout<'msg>() =
+        static member inline AbsoluteLayout<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabAbsoluteLayout, IFabView>(AbsoluteLayout.WidgetKey, LayoutOfView.Children)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/Border.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/Border.fs
@@ -82,7 +82,7 @@ module BorderBuilders =
         static member inline Border(content: WidgetBuilder<'msg, #IFabView>) =
             WidgetBuilder<'msg, IFabBorder>(
                 Border.WidgetKey,
-                AttributesBundle(StackList.empty(), ValueSome [| Border.Content.WithValue(content.Compile()) |], ValueNone)
+                AttributesBundle(StackList.empty(), [| Border.Content.WithValue(content.Compile()) |], [||], [||])
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/ContentView.fs
@@ -18,7 +18,7 @@ module ContentViewBuilders =
 
         /// <summary>Create a ContentView widget with a content</summary>
         /// <param name="content">The content widget</param>
-        static member inline ContentView<'msg, 'marker when 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline ContentView<'msg, 'marker when 'msg: equality and 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IFabContentView> ContentView.WidgetKey [| ContentView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/FlexLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/FlexLayout.fs
@@ -49,12 +49,12 @@ module FlexLayoutBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a FlexLayout</summary>
-        static member inline FlexLayout<'msg>() =
+        static member inline FlexLayout<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabFlexLayout, IFabView>(FlexLayout.WidgetKey, LayoutOfView.Children)
 
         /// <summary>Create a FlexLayout widget with a wrap value</summary>
         /// <param name="wrap">The wrap value</param>
-        static member inline FlexLayout<'msg>(wrap: FlexWrap) =
+        static member inline FlexLayout<'msg when 'msg: equality>(wrap: FlexWrap) =
             CollectionBuilder<'msg, IFabFlexLayout, IFabView>(FlexLayout.WidgetKey, LayoutOfView.Children, FlexLayout.Wrap.WithValue(wrap))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/Grid.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/Grid.fs
@@ -83,13 +83,13 @@ module GridBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a Grid widget with only one cell</summary>
-        static member inline Grid<'msg>() =
+        static member inline Grid<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabGrid, IFabView>(Grid.WidgetKey, LayoutOfView.Children)
 
         /// <summary>Create a Grid widget with the given column and row definitions</summary>
         /// <param name="coldefs">The column definitions</param>
         /// <param name="rowdefs">The row definitions</param>
-        static member inline Grid<'msg>(coldefs: seq<Dimension>, rowdefs: seq<Dimension>) =
+        static member inline Grid<'msg when 'msg: equality>(coldefs: seq<Dimension>, rowdefs: seq<Dimension>) =
             CollectionBuilder<'msg, IFabGrid, IFabView>(
                 Grid.WidgetKey,
                 LayoutOfView.Children,

--- a/src/Fabulous.MauiControls/Views/Layouts/HorizontalStackLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/HorizontalStackLayout.fs
@@ -15,12 +15,12 @@ module HorizontalStackLayoutBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Creates a HStack widget</summary>
-        static member inline HStack<'msg>() =
+        static member inline HStack<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabHorizontalStackLayout, IFabView>(HorizontalStackLayout.WidgetKey, LayoutOfView.Children)
 
         /// <summary>Creates a HStack widget with spacing between children</summary>
         /// <param name="spacing">The spacing between children</param>
-        static member inline HStack<'msg>(spacing: float) =
+        static member inline HStack<'msg when 'msg: equality>(spacing: float) =
             CollectionBuilder<'msg, IFabHorizontalStackLayout, IFabView>(
                 HorizontalStackLayout.WidgetKey,
                 LayoutOfView.Children,

--- a/src/Fabulous.MauiControls/Views/Layouts/RefreshView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/RefreshView.fs
@@ -17,7 +17,7 @@ module RefreshView =
     let RefreshColor = Attributes.defineBindableColor RefreshView.RefreshColorProperty
 
     let Refreshing =
-        Attributes.defineEventNoArg "RefreshView_Refreshing" (fun target -> (target :?> RefreshView).Refreshing)
+        Attributes.Mvu.defineEventNoArg "RefreshView_Refreshing" (fun target -> (target :?> RefreshView).Refreshing)
 
 [<AutoOpen>]
 module RefreshViewBuilders =
@@ -32,8 +32,9 @@ module RefreshViewBuilders =
                 RefreshView.WidgetKey,
                 AttributesBundle(
                     StackList.two(RefreshView.IsRefreshing.WithValue(isRefreshing), RefreshView.Refreshing.WithValue(MsgValue(onRefreshing))),
-                    ValueSome [| ContentView.Content.WithValue(content.Compile()) |],
-                    ValueNone
+                    [| ContentView.Content.WithValue(content.Compile()) |],
+                    [||],
+                    [||]
                 )
             )
 

--- a/src/Fabulous.MauiControls/Views/Layouts/ScrollView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/ScrollView.fs
@@ -27,7 +27,7 @@ module ScrollView =
         Attributes.defineBindableEnum<ScrollOrientation> ScrollView.OrientationProperty
 
     let Scrolled =
-        Attributes.defineEvent<ScrolledEventArgs> "ScrollView_Scrolled" (fun target -> (target :?> ScrollView).Scrolled)
+        Attributes.Mvu.defineEvent<ScrolledEventArgs> "ScrollView_Scrolled" (fun target -> (target :?> ScrollView).Scrolled)
 
     let ScrollPosition =
         Attributes.defineSimpleScalarWithEquality<ScrollToData> "ScrollView_ScrollPosition" (fun _ newValueOpt node ->
@@ -55,7 +55,7 @@ module ScrollViewBuilders =
 
         /// <summary>Create a ScrollView widget with a content</summary>
         /// <param name="content">The content of the ScrollView</param>
-        static member inline ScrollView<'msg, 'marker when 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline ScrollView<'msg, 'marker when 'msg: equality and 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetHelpers.buildWidgets<'msg, IFabScrollView> ScrollView.WidgetKey [| ScrollView.Content.WithValue(content.Compile()) |]
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/SwipeItem.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/SwipeItem.fs
@@ -15,7 +15,7 @@ module SwipeItem =
         Attributes.defineBindableColor SwipeItem.BackgroundColorProperty
 
     let Invoked =
-        Attributes.defineEvent "SwipeItem_Invoked" (fun target -> (target :?> SwipeItem).Invoked)
+        Attributes.Mvu.defineEvent "SwipeItem_Invoked" (fun target -> (target :?> SwipeItem).Invoked)
 
     let IsVisible = Attributes.defineBindableBool SwipeItem.IsVisibleProperty
 
@@ -25,7 +25,7 @@ module SwipeItemBuilders =
 
         /// <summary>Create a SwipeItem widget and listen for the Invoke event</summary>
         /// <param name="onInvoked">Message to dispatch</param>
-        static member inline SwipeItem<'msg>(onInvoked: 'msg) =
+        static member inline SwipeItem<'msg when 'msg: equality>(onInvoked: 'msg) =
             WidgetBuilder<'msg, IFabSwipeItem>(SwipeItem.WidgetKey, SwipeItem.Invoked.WithValue(fun _ -> box onInvoked))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/SwipeItems.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/SwipeItems.fs
@@ -27,7 +27,7 @@ module SwipeItemsBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a SwipeItems widget</summary>
-        static member inline SwipeItems<'msg>() =
+        static member inline SwipeItems<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabSwipeItems, IFabSwipeItem>(SwipeItems.WidgetKey, SwipeItems.SwipeItems)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Layouts/SwipeView.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/SwipeView.fs
@@ -13,23 +13,23 @@ module SwipeView =
     let BottomSwipeItems = Attributes.defineBindableWidget SwipeView.BottomItemsProperty
 
     let CloseRequested =
-        Attributes.defineEvent<CloseRequestedEventArgs> "SwipeView_CloseRequested" (fun target -> (target :?> SwipeView).CloseRequested)
+        Attributes.Mvu.defineEvent<CloseRequestedEventArgs> "SwipeView_CloseRequested" (fun target -> (target :?> SwipeView).CloseRequested)
 
     let LeftSwipeItems = Attributes.defineBindableWidget SwipeView.LeftItemsProperty
 
     let OpenRequested =
-        Attributes.defineEvent<OpenRequestedEventArgs> "SwipeView_OpenRequested" (fun target -> (target :?> SwipeView).OpenRequested)
+        Attributes.Mvu.defineEvent<OpenRequestedEventArgs> "SwipeView_OpenRequested" (fun target -> (target :?> SwipeView).OpenRequested)
 
     let RightSwipeItems = Attributes.defineBindableWidget SwipeView.RightItemsProperty
 
     let SwipeChanging =
-        Attributes.defineEvent<SwipeChangingEventArgs> "SwipeView_SwipeChanging" (fun target -> (target :?> SwipeView).SwipeChanging)
+        Attributes.Mvu.defineEvent<SwipeChangingEventArgs> "SwipeView_SwipeChanging" (fun target -> (target :?> SwipeView).SwipeChanging)
 
     let SwipeEnded =
-        Attributes.defineEvent<SwipeEndedEventArgs> "SwipeView_SwipeEnded" (fun target -> (target :?> SwipeView).SwipeEnded)
+        Attributes.Mvu.defineEvent<SwipeEndedEventArgs> "SwipeView_SwipeEnded" (fun target -> (target :?> SwipeView).SwipeEnded)
 
     let SwipeStarted =
-        Attributes.defineEvent<SwipeStartedEventArgs> "SwipeView_SwipeStarted" (fun target -> (target :?> SwipeView).SwipeStarted)
+        Attributes.Mvu.defineEvent<SwipeStartedEventArgs> "SwipeView_SwipeStarted" (fun target -> (target :?> SwipeView).SwipeStarted)
 
     let SwipeThreshold = Attributes.defineBindableInt SwipeView.ThresholdProperty
 

--- a/src/Fabulous.MauiControls/Views/Layouts/VerticalStackLayout.fs
+++ b/src/Fabulous.MauiControls/Views/Layouts/VerticalStackLayout.fs
@@ -15,12 +15,12 @@ module VerticalStackLayoutBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Creates a VStack widget</summary>
-        static member inline VStack<'msg>() =
+        static member inline VStack<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabVerticalStackLayout, IFabView>(VerticalStackLayout.WidgetKey, LayoutOfView.Children)
 
         /// <summary>Creates a VStack widget with spacing between children</summary>
         /// <param name="spacing">The spacing between children</param>
-        static member inline VStack<'msg>(spacing: float) =
+        static member inline VStack<'msg when 'msg: equality>(spacing: float) =
             CollectionBuilder<'msg, IFabVerticalStackLayout, IFabView>(
                 VerticalStackLayout.WidgetKey,
                 LayoutOfView.Children,

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuFlyoutItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuFlyoutItem.fs
@@ -21,7 +21,7 @@ module MenuFlyoutItemBuilders =
         /// <summary>Create a MenuItem widget with a text and a Click callback</summary>
         /// <param name="text">The text</param>
         /// <param name="onClicked">The click callback</param>
-        static member inline MenuFlyoutItem<'msg>(text: string, onClicked: 'msg) =
+        static member inline MenuFlyoutItem<'msg when 'msg: equality>(text: string, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabMenuFlyoutItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]
@@ -29,7 +29,7 @@ type MenuFlyoutItemModifiers =
     /// <summary>Set the keyboard accelerators of this widget</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline keyboardAccelerators<'msg, 'marker when 'marker :> IFabMenuFlyoutItem>(this: WidgetBuilder<'msg, 'marker>) =
+    static member inline keyboardAccelerators<'msg, 'marker when 'msg: equality and 'marker :> IFabMenuFlyoutItem>(this: WidgetBuilder<'msg, 'marker>) =
         WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabKeyboardAccelerator> MenuFlyoutItem.KeyboardAccelerators this
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/MenuItem.fs
@@ -18,7 +18,7 @@ module MenuItem =
     let Accelerator = Attributes.defineBindableWithEquality MenuItem.AcceleratorProperty
 
     let Clicked =
-        Attributes.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> MenuItem).Clicked)
+        Attributes.Mvu.defineEventNoArg "MenuItem_Clicked" (fun target -> (target :?> MenuItem).Clicked)
 
     let IconImageSource =
         Attributes.defineBindableImageSource MenuItem.IconImageSourceProperty
@@ -34,7 +34,7 @@ module MenuItemBuilders =
         /// <summary>Create a MenuItem widget with a text and a Click callback</summary>
         /// <param name="text">The text</param>
         /// <param name="onClicked">The click callback</param>
-        static member inline MenuItem<'msg>(text: string, onClicked: 'msg) =
+        static member inline MenuItem<'msg when 'msg: equality>(text: string, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabMenuItem>(MenuItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/MenuItems/ToolbarItem.fs
+++ b/src/Fabulous.MauiControls/Views/MenuItems/ToolbarItem.fs
@@ -33,7 +33,7 @@ module ToolbarItemBuilders =
         /// <summary>Create a ToolbarItem widget with a text and a Click callback</summary>
         /// <param name="text">The text</param>
         /// <param name="onClicked">The click callback</param>
-        static member inline ToolbarItem<'msg>(text: string, onClicked: 'msg) =
+        static member inline ToolbarItem<'msg when 'msg: equality>(text: string, onClicked: 'msg) =
             WidgetBuilder<'msg, IFabToolbarItem>(ToolbarItem.WidgetKey, MenuItem.Text.WithValue(text), MenuItem.Clicked.WithValue(MsgValue(onClicked)))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Pages/ContentPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/ContentPage.fs
@@ -31,7 +31,7 @@ module ContentPage =
     let Content = Attributes.defineBindableWidget ContentPage.ContentProperty
 
     let SizeAllocated =
-        Attributes.defineEvent<SizeAllocatedEventArgs> "ContentPage_SizeAllocated" (fun target -> (target :?> FabContentPage).SizeAllocated)
+        Attributes.Mvu.defineEvent<SizeAllocatedEventArgs> "ContentPage_SizeAllocated" (fun target -> (target :?> FabContentPage).SizeAllocated)
 
 [<AutoOpen>]
 module ContentPageBuilders =
@@ -39,14 +39,11 @@ module ContentPageBuilders =
 
         /// <summary>Create a ContentPage with a content widget</summary>
         /// <param name="content">The content widget</param>
-        static member inline ContentPage<'msg, 'marker when 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
+        static member inline ContentPage<'msg, 'marker when 'msg: equality and 'marker :> IFabView>(content: WidgetBuilder<'msg, 'marker>) =
             WidgetBuilder<'msg, IFabContentPage>(
                 ContentPage.WidgetKey,
-                AttributesBundle(StackList.empty(), ValueSome [| ContentPage.Content.WithValue(content.Compile()) |], ValueNone)
+                AttributesBundle(StackList.empty(), [| ContentPage.Content.WithValue(content.Compile()) |], [||], [||])
             )
-
-        static member inline ContentPage<'msg, 'childMarker>() =
-            SingleChildBuilder<'msg, IFabContentPage, 'childMarker>(ContentPage.WidgetKey, ContentPage.Content)
 
 [<Extension>]
 type ContentPageModifiers =

--- a/src/Fabulous.MauiControls/Views/Pages/FlyoutPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/FlyoutPage.fs
@@ -26,7 +26,7 @@ module FlyoutPage =
     let WidgetKey = Widgets.register<FabFlyoutPage>()
 
     let BackButtonPressed =
-        Attributes.defineEvent "FlyoutPage_BackButtonPressed" (fun target -> (target :?> FlyoutPage).BackButtonPressed)
+        Attributes.Mvu.defineEvent "FlyoutPage_BackButtonPressed" (fun target -> (target :?> FlyoutPage).BackButtonPressed)
 
     let Detail =
         Attributes.definePropertyWidget "FlyoutPage_Detail" (fun target -> (target :?> FlyoutPage).Detail :> obj) (fun target value ->

--- a/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/NavigationPage.fs
@@ -269,10 +269,10 @@ module NavigationPage =
     let WidgetKey = Widgets.register<FabNavigationPage>()
 
     let BackButtonPressed =
-        Attributes.defineEventNoArg "NavigationPage_BackButtonPressed" (fun target -> (target :?> FabNavigationPage).BackButtonPressed)
+        Attributes.Mvu.defineEventNoArg "NavigationPage_BackButtonPressed" (fun target -> (target :?> FabNavigationPage).BackButtonPressed)
 
     let BackNavigated =
-        Attributes.defineEventNoArg "NavigationPage_BackNavigated" (fun target -> (target :?> FabNavigationPage).BackNavigated)
+        Attributes.Mvu.defineEventNoArg "NavigationPage_BackNavigated" (fun target -> (target :?> FabNavigationPage).BackNavigated)
 
     let BarBackground =
         Attributes.defineBindableWithEquality NavigationPage.BarBackgroundProperty
@@ -345,7 +345,7 @@ module NavigationPageBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a NavigationPage widget</summary>
-        static member inline NavigationPage<'msg>() =
+        static member inline NavigationPage<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabNavigationPage, IFabPage>(NavigationPage.WidgetKey, NavigationPage.Pages)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Pages/TabbedPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/TabbedPage.fs
@@ -40,7 +40,7 @@ module TabbedPageBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a TabbedPage widget</summary>
-        static member inline TabbedPage<'msg>() =
+        static member inline TabbedPage<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabTabbedPage, IFabPage>(TabbedPage.WidgetKey, MultiPageOfPage.Children)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Pages/_MultiPageOfPage.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_MultiPageOfPage.fs
@@ -15,7 +15,7 @@ module MultiPageOfPage =
 
     [<Obsolete("Use CurrentPageWithEvent instead")>]
     let CurrentPageChanged =
-        Attributes.defineEventNoArg "MultiPageOfPage_CurrentPageChanged" (fun target -> (target :?> MultiPage<Page>).CurrentPageChanged)
+        Attributes.Mvu.defineEventNoArg "MultiPageOfPage_CurrentPageChanged" (fun target -> (target :?> MultiPage<Page>).CurrentPageChanged)
 
     let CurrentPageWithEvent =
         let name = "MultiPageOfPage_CurrentPageWithEvent"

--- a/src/Fabulous.MauiControls/Views/Pages/_Page.fs
+++ b/src/Fabulous.MauiControls/Views/Pages/_Page.fs
@@ -14,13 +14,13 @@ type IFabPage =
 
 module Page =
     let Appearing =
-        Attributes.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Page).Appearing)
+        Attributes.Mvu.defineEventNoArg "Page_Appearing" (fun target -> (target :?> Page).Appearing)
 
     let BackgroundImageSource =
         Attributes.defineBindableImageSource Page.BackgroundImageSourceProperty
 
     let Disappearing =
-        Attributes.defineEventNoArg "Page_Disappearing" (fun target -> (target :?> Page).Disappearing)
+        Attributes.Mvu.defineEventNoArg "Page_Disappearing" (fun target -> (target :?> Page).Disappearing)
 
     let IconImageSource =
         Attributes.defineBindableImageSource Page.IconImageSourceProperty
@@ -28,10 +28,10 @@ module Page =
     let IsBusy = Attributes.defineBindableBool Page.IsBusyProperty
 
     let NavigatedTo =
-        Attributes.defineEvent "NavigatedTo" (fun target -> (target :?> Page).NavigatedTo)
+        Attributes.Mvu.defineEvent "NavigatedTo" (fun target -> (target :?> Page).NavigatedTo)
 
     let NavigatedFrom =
-        Attributes.defineEvent "NavigatedFrom" (fun target -> (target :?> Page).NavigatedFrom)
+        Attributes.Mvu.defineEvent "NavigatedFrom" (fun target -> (target :?> Page).NavigatedFrom)
 
     let Padding = Attributes.defineBindableWithEquality Page.PaddingProperty
 
@@ -113,7 +113,7 @@ type PageModifiers =
     /// <summary>Set the toolbar items of this page menu</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline toolbarItems<'msg, 'marker when 'marker :> IFabPage>(this: WidgetBuilder<'msg, 'marker>) =
+    static member inline toolbarItems<'msg, 'marker when 'msg: equality and 'marker :> IFabPage>(this: WidgetBuilder<'msg, 'marker>) =
         WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabToolbarItem> Page.ToolbarItems this
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Ellipse.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Ellipse.fs
@@ -17,8 +17,8 @@ module EllipseBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create an Ellipse widget</summary>
-        static member inline Ellipse<'msg>() =
-            WidgetBuilder<'msg, IFabEllipse>(Ellipse.WidgetKey, AttributesBundle(StackList.empty(), ValueNone, ValueNone))
+        static member inline Ellipse<'msg when 'msg: equality>() =
+            WidgetBuilder<'msg, IFabEllipse>(Ellipse.WidgetKey, AttributesBundle(StackList.empty(), [||], [||], [||]))
 
 [<Extension>]
 type EllipseModifiers =

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/EllipseGeometry.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/EllipseGeometry.fs
@@ -26,7 +26,7 @@ module EllipseGeometryBuilders =
         /// <param name="center">The center point</param>
         /// <param name="radiusX">The X component of the radius</param>
         /// <param name="radiusY">The Y component of the radius</param>
-        static member inline EllipseGeometry<'msg>(center: Point, radiusX: float, radiusY: float) =
+        static member inline EllipseGeometry<'msg when 'msg: equality>(center: Point, radiusX: float, radiusY: float) =
             WidgetBuilder<'msg, IFabEllipseGeometry>(
                 EllipseGeometry.WidgetKey,
                 EllipseGeometry.Center.WithValue(center),

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/GeometryGroup.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/GeometryGroup.fs
@@ -23,12 +23,12 @@ module GeometryGroupBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a GeometryGroup</summary>
-        static member inline GeometryGroup<'msg>() =
+        static member inline GeometryGroup<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabGeometryGroup, IFabGeometry>(GeometryGroup.WidgetKey, GeometryGroup.Children)
 
         /// <summary>Create a GeometryGroup with a fill rule</summary>
         /// <param name="fillRule">The fill rule</param>
-        static member inline GeometryGroup<'msg>(fillRule: FillRule) =
+        static member inline GeometryGroup<'msg when 'msg: equality>(fillRule: FillRule) =
             CollectionBuilder<'msg, IFabGeometryGroup, IFabGeometry>(
                 GeometryGroup.WidgetKey,
                 GeometryGroup.Children,

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/LineGeometry.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/LineGeometry.fs
@@ -24,7 +24,7 @@ module LineGeometryBuilders =
         /// <summary>Create a LineGeometry widget with a start point and an end point</summary>
         /// <param name="startPoint">The start point</param>
         /// <param name="endPoint">The end point</param>
-        static member inline LineGeometry<'msg>(startPoint: Point, endPoint: Point) =
+        static member inline LineGeometry<'msg when 'msg: equality>(startPoint: Point, endPoint: Point) =
             WidgetBuilder<'msg, IFabLineGeometry>(
                 LineGeometry.WidgetKey,
                 LineGeometry.StartPoint.WithValue(startPoint),

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/PathGeometry.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/PathGeometry.fs
@@ -31,12 +31,12 @@ module PathGeometryBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a PathGeometry widget</summary>
-        static member inline PathGeometry<'msg>() =
+        static member inline PathGeometry<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabPathGeometry, IFabPathFigure>(PathGeometry.WidgetKey, PathGeometry.FiguresWidgets)
 
         /// <summary>Create a PathGeometry widget with the fill rule</summary>
         /// <param name="fillRule">The fill rule</param>
-        static member inline PathGeometry<'msg>(fillRule: FillRule) =
+        static member inline PathGeometry<'msg when 'msg: equality>(fillRule: FillRule) =
             CollectionBuilder<'msg, IFabPathGeometry, IFabPathFigure>(
                 PathGeometry.WidgetKey,
                 PathGeometry.FiguresWidgets,
@@ -45,13 +45,13 @@ module PathGeometryBuilders =
 
         /// <summary>Create a PathGeometry widget with a figure data string and a fill rule</summary>
         /// <param name="figures">The figure data string</param>
-        static member inline PathGeometry<'msg>(figures: string) =
+        static member inline PathGeometry<'msg when 'msg: equality>(figures: string) =
             WidgetBuilder<'msg, IFabPathGeometry>(PathGeometry.WidgetKey, PathGeometry.FiguresString.WithValue(figures))
 
         /// <summary>Create a PathGeometry widget with a figure data string and a fill rule</summary>
         /// <param name="figures">The figure data string</param>
         /// <param name="fillRule">The fill rule</param>
-        static member inline PathGeometry<'msg>(figures: string, fillRule: FillRule) =
+        static member inline PathGeometry<'msg when 'msg: equality>(figures: string, fillRule: FillRule) =
             WidgetBuilder<'msg, IFabPathGeometry>(
                 PathGeometry.WidgetKey,
                 PathGeometry.FiguresString.WithValue(figures),

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/RectangleGeometry.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/RectangleGeometry.fs
@@ -20,7 +20,7 @@ module RectangleGeometryBuilders =
 
         /// <summary>Create a RectangleGeometry widget with a dimension</summary>
         /// <param name="rect">The dimension value</param>
-        static member inline RectangleGeometry<'msg>(rect: Rect) =
+        static member inline RectangleGeometry<'msg when 'msg: equality>(rect: Rect) =
             WidgetBuilder<'msg, IFabRectangleGeometry>(RectangleGeometry.WidgetKey, RectangleGeometry.Rect.WithValue(rect))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Geometries/RoundRectangleGeometry.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Geometries/RoundRectangleGeometry.fs
@@ -29,7 +29,7 @@ module RoundRectangleGeometryBuilders =
         /// <summary>Create a RoundRectangleGeometry widget with a corner radius and a dimension</summary>
         /// <param name="cornerRadius">The corner radius</param>
         /// <param name="rect">The dimension</param>
-        static member inline RoundRectangleGeometry<'msg>(cornerRadius: CornerRadius, rect: Rect) =
+        static member inline RoundRectangleGeometry<'msg when 'msg: equality>(cornerRadius: CornerRadius, rect: Rect) =
             WidgetBuilder<'msg, IFabRoundRectangleGeometry>(
                 RoundRectangleGeometry.WidgetKey,
                 RoundRectangleGeometry.CornerRadius.WithValue(cornerRadius),

--- a/src/Fabulous.MauiControls/Views/Shapes/Line.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Line.fs
@@ -36,7 +36,7 @@ module LineBuilders =
         /// <summary>Create a Line widget with a start point, an end point, a stroke thickness, and a stroke brush</summary>
         /// <param name="startPoint">The start point</param>
         /// <param name="endPoint">The end point</param>
-        static member inline Line<'msg>(startPoint: Point, endPoint: Point) =
+        static member inline Line<'msg when 'msg: equality>(startPoint: Point, endPoint: Point) =
             WidgetBuilder<'msg, IFabLine>(Line.WidgetKey, Line.Points.WithValue(struct (startPoint, endPoint)))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Path.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Path.fs
@@ -40,7 +40,7 @@ module PathBuilders =
 
         /// <summary>Create a Path widget with a data path string</summary>
         /// <param name="data">The data path</param>
-        static member inline Path<'msg>(data: string) =
+        static member inline Path<'msg when 'msg: equality>(data: string) =
             WidgetBuilder<'msg, IFabPath>(Path.WidgetKey, Path.DataString.WithValue(data))
 
         /// <summary>Create a Path widget with a Geometry widget</summary>

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/CompositeTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/CompositeTransform.fs
@@ -71,7 +71,7 @@ module CompositeTransformBuilders =
         /// <param name="scaleY">The Y component of the scale</param>
         /// <param name="skewX">The X component of the skew</param>
         /// <param name="skewY">The Y component of the skew</param>
-        static member inline CompositeTransform<'msg>(centerX: float, centerY: float, scaleX: float, scaleY: float, skewX: float, skewY: float) =
+        static member inline CompositeTransform<'msg when 'msg: equality>(centerX: float, centerY: float, scaleX: float, scaleY: float, skewX: float, skewY: float) =
             WidgetBuilder<'msg, IFabCompositeTransform>(
                 CompositeTransform.WidgetKey,
                 CompositeTransform.CenterXY.WithValue(struct (centerX, centerY)),

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/MatrixTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/MatrixTransform.fs
@@ -36,7 +36,7 @@ module MatrixTransformBuilders =
         /// <param name="m22">The M22 component of the matrix transform</param>
         /// <param name="offsetX">The X component of the offset</param>
         /// <param name="offsetY">The Y component of the offset</param>
-        static member inline MatrixTransform<'msg>(m11: float, m12: float, m21: float, m22: float, offsetX: float, offsetY: float) =
+        static member inline MatrixTransform<'msg when 'msg: equality>(m11: float, m12: float, m21: float, m22: float, offsetX: float, offsetY: float) =
             WidgetBuilder<'msg, IFabMatrixTransform>(MatrixTransform.WidgetKey, MatrixTransform.Matrix.WithValue(struct (m11, m12, m21, m22, offsetX, offsetY)))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/RotateTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/RotateTransform.fs
@@ -24,7 +24,7 @@ module RotateTransformBuilders =
         /// <param name="angle">The angle value</param>
         /// <param name="centerX">The X position</param>
         /// <param name="centerY">The Y position</param>
-        static member inline RotateTransform<'msg>(angle: float, centerX: float, centerY: float) =
+        static member inline RotateTransform<'msg when 'msg: equality>(angle: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IFabRotateTransform>(
                 RotateTransform.WidgetKey,
                 RotateTransform.Angle.WithValue(angle),

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/ScaleTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/ScaleTransform.fs
@@ -35,7 +35,7 @@ module ScaleTransformBuilders =
         /// <param name="scaleY">The Y component of the scale</param>
         /// <param name="centerX">The X position of the center</param>
         /// <param name="centerY">The Y position of the center</param>
-        static member inline ScaleTransform<'msg>(scaleX: float, scaleY: float, centerX: float, centerY: float) =
+        static member inline ScaleTransform<'msg when 'msg: equality>(scaleX: float, scaleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IFabScaleTransform>(
                 ScaleTransform.WidgetKey,
                 ScaleTransform.ScaleXY.WithValue(struct (scaleX, scaleY)),

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/SkewTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/SkewTransform.fs
@@ -35,7 +35,7 @@ module SkewTransformBuilders =
         /// <param name="angleY">The Y component of the angle</param>
         /// <param name="centerX">The X position of the center</param>
         /// <param name="centerY">The Y position of the center</param>
-        static member inline SkewTransform<'msg>(angleX: float, angleY: float, centerX: float, centerY: float) =
+        static member inline SkewTransform<'msg when 'msg: equality>(angleX: float, angleY: float, centerX: float, centerY: float) =
             WidgetBuilder<'msg, IFabSkewTransform>(
                 SkewTransform.WidgetKey,
                 SkewTransform.AnglesXY.WithValue(struct (angleX, angleY)),

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/TransformGroup.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/TransformGroup.fs
@@ -20,7 +20,7 @@ module TransformGroupBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a TransformGroup widget</summary>
-        static member inline TransformGroup<'msg>() =
+        static member inline TransformGroup<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabTransformGroup, IFabTransform>(TransformGroup.WidgetKey, TransformGroup.Children)
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/TranslateTransform.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/PathTransforms/TranslateTransform.fs
@@ -21,7 +21,7 @@ module TranslateTransformBuilders =
         /// <summary>Create a TranslateTransform widget with translation value</summary>
         /// <param name="x">The X component of the translation</param>
         /// <param name="y">The Y component of the translation</param>
-        static member inline TranslateTransform<'msg>(x: float, y: float) =
+        static member inline TranslateTransform<'msg when 'msg: equality>(x: float, y: float) =
             WidgetBuilder<'msg, IFabTranslateTransform>(TranslateTransform.WidgetKey, TranslateTransform.X.WithValue(x), TranslateTransform.Y.WithValue(y))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Polygon.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Polygon.fs
@@ -40,7 +40,7 @@ module PolygonBuilders =
 
         /// <summary>Create a Polygon widget with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline Polygon<'msg>(points: string) =
+        static member inline Polygon<'msg when 'msg: equality>(points: string) =
             WidgetBuilder<'msg, IFabPolygon>(Polygon.WidgetKey, Polygon.PointsString.WithValue(points))
 
         /// <summary>Create a Polygon widget with a list of points</summary>

--- a/src/Fabulous.MauiControls/Views/Shapes/Polyline.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Polyline.fs
@@ -43,7 +43,7 @@ module PolylineBuilders =
 
         /// <summary>Create a Polyline widget with a list of points, a stroke thickness, a stroke brush</summary>
         /// <param name="points">The points list</param>
-        static member inline Polyline<'msg>(points: string) =
+        static member inline Polyline<'msg when 'msg: equality>(points: string) =
             WidgetBuilder<'msg, IFabPolyline>(Polyline.WidgetKey, Polyline.PointsString.WithValue(points))
 
         /// <summary>Create a Polyline widget with a list of points, a stroke thickness, a stroke brush</summary>

--- a/src/Fabulous.MauiControls/Views/Shapes/Rectangle.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Rectangle.fs
@@ -22,7 +22,7 @@ module RectangleBuilders =
 
         /// <summary>Create a Rectangle widget</summary>
         static member inline Rectangle() =
-            WidgetBuilder<'msg, IFabRectangle>(Rectangle.WidgetKey, AttributesBundle(StackList.empty(), ValueNone, ValueNone))
+            WidgetBuilder<'msg, IFabRectangle>(Rectangle.WidgetKey, AttributesBundle(StackList.empty(), [||], [||], [||]))
 
 [<Extension>]
 type RectangleModifiers =

--- a/src/Fabulous.MauiControls/Views/Shapes/RoundRectangle.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/RoundRectangle.fs
@@ -22,7 +22,7 @@ module RoundRectangleBuilders =
 
         /// <summary>Create a RoundRectangle widget with a corner radius</summary>
         /// <param name="cornerRadius">The corner radius</param>
-        static member inline RoundRectangle<'msg>(cornerRadius: CornerRadius) =
+        static member inline RoundRectangle<'msg when 'msg: equality>(cornerRadius: CornerRadius) =
             WidgetBuilder<'msg, IFabRoundRectangle>(RoundRectangle.WidgetKey, RoundRectangle.CornerRadius.WithValue(cornerRadius))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/ArcSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/ArcSegment.fs
@@ -30,7 +30,7 @@ module ArcSegmentBuilders =
         /// <summary>Create a ArcSegment widget</summary>
         /// <param name="point">The point</param>
         /// <param name="size">The size</param>
-        static member inline ArcSegment<'msg>(point: Point, size: Size) =
+        static member inline ArcSegment<'msg when 'msg: equality>(point: Point, size: Size) =
             WidgetBuilder<'msg, IFabArcSegment>(ArcSegment.WidgetKey, ArcSegment.Point.WithValue(point), ArcSegment.Size.WithValue(size))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/BezierSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/BezierSegment.fs
@@ -28,7 +28,7 @@ module BezierSegmentBuilders =
         /// <param name="point1">The first point</param>
         /// <param name="point2">The second point</param>
         /// <param name="point3">The third point</param>
-        static member inline BezierSegment<'msg>(point1: Point, point2: Point, point3: Point) =
+        static member inline BezierSegment<'msg when 'msg: equality>(point1: Point, point2: Point, point3: Point) =
             WidgetBuilder<'msg, IFabBezierSegment>(
                 BezierSegment.WidgetKey,
                 BezierSegment.Point1.WithValue(point1),

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/LineSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/LineSegment.fs
@@ -19,7 +19,7 @@ module LineSegmentBuilders =
 
         /// <summary>Create a LineSegment widget with a start and end point</summary>
         /// <param name="point">The start and end point</param>
-        static member inline LineSegment<'msg>(point: Point) =
+        static member inline LineSegment<'msg when 'msg: equality>(point: Point) =
             WidgetBuilder<'msg, IFabLineSegment>(LineSegment.WidgetKey, LineSegment.Point.WithValue(point))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/PathFigure.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/PathFigure.fs
@@ -28,12 +28,12 @@ module PathFigureBuilders =
     type Fabulous.Maui.View with
 
         /// <summary>Create a PathFigure widget</summary>
-        static member inline PathFigure<'msg>() =
+        static member inline PathFigure<'msg when 'msg: equality>() =
             CollectionBuilder<'msg, IFabPathFigure, IFabPathSegment>(PathFigure.WidgetKey, PathFigure.Segments)
 
         /// <summary>Create a PathFigure widget with a start point</summary>
         /// <param name="startPoint">The start point</param>
-        static member inline PathFigure<'msg>(startPoint: Point) =
+        static member inline PathFigure<'msg when 'msg: equality>(startPoint: Point) =
             CollectionBuilder<'msg, IFabPathFigure, IFabPathSegment>(PathFigure.WidgetKey, PathFigure.Segments, PathFigure.StartPoint.WithValue(startPoint))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyBezierSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyBezierSegment.fs
@@ -37,12 +37,12 @@ module PolyBezierSegmentBuilders =
 
         /// <summary>Create a PolyBezierSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyBezierSegment<'msg>(points: string) =
+        static member inline PolyBezierSegment<'msg when 'msg: equality>(points: string) =
             WidgetBuilder<'msg, IFabPolyBezierSegment>(PolyBezierSegment.WidgetKey, PolyBezierSegment.PointsString.WithValue(points))
 
         /// <summary>Create a PolyBezierSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyBezierSegment<'msg>(points: seq<Point>) =
+        static member inline PolyBezierSegment<'msg when 'msg: equality>(points: seq<Point>) =
             WidgetBuilder<'msg, IFabPolyBezierSegment>(PolyBezierSegment.WidgetKey, PolyBezierSegment.PointsList.WithValue(Array.ofSeq points))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyLineSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyLineSegment.fs
@@ -37,12 +37,12 @@ module PolyLineSegmentBuilders =
 
         /// <summary>Create a PolyLineSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyLineSegment<'msg>(points: string) =
+        static member inline PolyLineSegment<'msg when 'msg: equality>(points: string) =
             WidgetBuilder<'msg, IFabPolyLineSegment>(PolyLineSegment.WidgetKey, PolyLineSegment.PointsString.WithValue(points))
 
         /// <summary>Create a PolyLineSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyLineSegment<'msg>(points: seq<Point>) =
+        static member inline PolyLineSegment<'msg when 'msg: equality>(points: seq<Point>) =
             WidgetBuilder<'msg, IFabPolyLineSegment>(PolyLineSegment.WidgetKey, PolyLineSegment.PointsList.WithValue(Array.ofSeq points))
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyQuadraticBezierSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/PolyQuadraticBezierSegment.fs
@@ -37,12 +37,12 @@ module PolyQuadraticBezierSegmentBuilders =
 
         /// <summary>Create a PolyQuadraticBezierSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyQuadraticBezierSegment<'msg>(points: string) =
+        static member inline PolyQuadraticBezierSegment<'msg when 'msg: equality>(points: string) =
             WidgetBuilder<'msg, IFabPolyQuadraticBezierSegment>(PolyQuadraticBezierSegment.WidgetKey, PolyQuadraticBezierSegment.PointsString.WithValue(points))
 
         /// <summary>Create a PolyQuadraticBezierSegment with a list of points</summary>
         /// <param name="points">The points list</param>
-        static member inline PolyQuadraticBezierSegment<'msg>(points: seq<Point>) =
+        static member inline PolyQuadraticBezierSegment<'msg when 'msg: equality>(points: seq<Point>) =
             WidgetBuilder<'msg, IFabPolyQuadraticBezierSegment>(
                 PolyQuadraticBezierSegment.WidgetKey,
                 PolyQuadraticBezierSegment.PointsList.WithValue(Array.ofSeq points)

--- a/src/Fabulous.MauiControls/Views/Shapes/Segments/QuadraticBezierSegment.fs
+++ b/src/Fabulous.MauiControls/Views/Shapes/Segments/QuadraticBezierSegment.fs
@@ -24,7 +24,7 @@ module QuadraticBezierSegmentBuilders =
         /// <summary>Create a QuadraticBezierSegment with a list of points</summary>
         /// <param name="point1">The first point</param>
         /// <param name="point2">The second point</param>
-        static member inline QuadraticBezierSegment<'msg>(point1: Point, point2: Point) =
+        static member inline QuadraticBezierSegment<'msg when 'msg: equality>(point1: Point, point2: Point) =
             WidgetBuilder<'msg, IFabQuadraticBezierSegment>(
                 QuadraticBezierSegment.WidgetKey,
                 QuadraticBezierSegment.Point1.WithValue(point1),

--- a/src/Fabulous.MauiControls/Views/Window.fs
+++ b/src/Fabulous.MauiControls/Views/Window.fs
@@ -31,31 +31,31 @@ module Window =
     let MinimumWidth = Attributes.defineBindableWithEquality Window.MinimumWidthProperty
 
     let Activated =
-        Attributes.defineEventNoArg "Window_Activated" (fun target -> (target :?> Window).Activated)
+        Attributes.Mvu.defineEventNoArg "Window_Activated" (fun target -> (target :?> Window).Activated)
 
     let Backgrounding =
-        Attributes.defineEvent "Window_Backgrounding" (fun target -> (target :?> Window).Backgrounding)
+        Attributes.Mvu.defineEvent "Window_Backgrounding" (fun target -> (target :?> Window).Backgrounding)
 
     let Created =
-        Attributes.defineEventNoArg "Window_Created" (fun target -> (target :?> Window).Created)
+        Attributes.Mvu.defineEventNoArg "Window_Created" (fun target -> (target :?> Window).Created)
 
     let Deactivated =
-        Attributes.defineEventNoArg "Window_Deactivated" (fun target -> (target :?> Window).Deactivated)
+        Attributes.Mvu.defineEventNoArg "Window_Deactivated" (fun target -> (target :?> Window).Deactivated)
 
     let Destroying =
-        Attributes.defineEventNoArg "Window_Destroying" (fun target -> (target :?> Window).Destroying)
+        Attributes.Mvu.defineEventNoArg "Window_Destroying" (fun target -> (target :?> Window).Destroying)
 
     let DisplayDensityChanged =
-        Attributes.defineEvent "Window_DisplayDensityChanged" (fun target -> (target :?> Window).DisplayDensityChanged)
+        Attributes.Mvu.defineEvent "Window_DisplayDensityChanged" (fun target -> (target :?> Window).DisplayDensityChanged)
 
     let SizeChanged =
-        Attributes.defineEventNoArg "Window_SizeChanged" (fun target -> (target :?> Window).SizeChanged)
+        Attributes.Mvu.defineEventNoArg "Window_SizeChanged" (fun target -> (target :?> Window).SizeChanged)
 
     let Resumed =
-        Attributes.defineEventNoArg "Window_Resumed" (fun target -> (target :?> Window).Resumed)
+        Attributes.Mvu.defineEventNoArg "Window_Resumed" (fun target -> (target :?> Window).Resumed)
 
     let Stopped =
-        Attributes.defineEventNoArg "Window_Stopped" (fun target -> (target :?> Window).Stopped)
+        Attributes.Mvu.defineEventNoArg "Window_Stopped" (fun target -> (target :?> Window).Stopped)
 
     let Title = Attributes.defineBindableWithEquality Window.TitleProperty
 
@@ -72,7 +72,7 @@ module WindowBuilders =
         static member inline Window(content: WidgetBuilder<'msg, #IFabPage>) =
             WidgetBuilder<'msg, IFabWindow>(
                 Window.WidgetKey,
-                AttributesBundle(StackList.empty(), ValueSome [| Window.Page.WithValue(content.Compile()) |], ValueNone)
+                AttributesBundle(StackList.empty(), [| Window.Page.WithValue(content.Compile()) |], [||], [||])
             )
 
 [<Extension>]

--- a/src/Fabulous.MauiControls/Views/_View.fs
+++ b/src/Fabulous.MauiControls/Views/_View.fs
@@ -26,7 +26,7 @@ type ViewModifiers =
     /// <summary>Set the gesture recognizers associated with this widget</summary>
     /// <param name="this">Current widget</param>
     [<Extension>]
-    static member inline gestureRecognizers<'msg, 'marker when 'marker :> IFabView>(this: WidgetBuilder<'msg, 'marker>) =
+    static member inline gestureRecognizers<'msg, 'marker when 'msg: equality and 'marker :> IFabView>(this: WidgetBuilder<'msg, 'marker>) =
         WidgetHelpers.buildAttributeCollection<'msg, 'marker, IFabGestureRecognizer> View'.GestureRecognizers this
 
     /// <summary>Set the LayoutOptions that define how the widget gets laid in a layout cycle</summary>

--- a/src/Fabulous.MauiControls/VirtualizedCollection.fs
+++ b/src/Fabulous.MauiControls/VirtualizedCollection.fs
@@ -33,7 +33,7 @@ type WidgetDataTemplate(parent: IViewNode, ``type``: Type, templateFn: obj -> Wi
             let bindableObject = Activator.CreateInstance ``type`` :?> BindableObject
 
             let viewNode =
-                new ViewNode(Some parent, parent.TreeContext, WeakReference(bindableObject))
+                new ViewNode(Some parent, parent.EnvironmentContext, parent.TreeContext, WeakReference(bindableObject))
 
             bindableObject.SetValue(ViewNode.ViewNodeProperty, viewNode)
 

--- a/src/Fabulous.MauiControls/Widgets.fs
+++ b/src/Fabulous.MauiControls/Widgets.fs
@@ -23,7 +23,7 @@ module Widgets =
               Name = typeof<'T>.Name
               TargetType = typeof<'T>
               CreateView =
-                fun (widget, treeContext, parentNode) ->
+                fun (widget, envContext, treeContext, parentNode) ->
                     treeContext.Logger.Debug("Creating view for {0}", typeof<'T>.Name)
 
                     let view = new 'T()
@@ -34,7 +34,7 @@ module Widgets =
                         | ValueNone -> None
                         | ValueSome node -> Some node
 
-                    let node = new ViewNode(parentNode, treeContext, weakReference)
+                    let node = new ViewNode(parentNode, envContext, treeContext, weakReference)
 
                     ViewNode.set node view
 
@@ -43,7 +43,7 @@ module Widgets =
                     Reconciler.update treeContext.CanReuseView ValueNone widget node
                     struct (node :> IViewNode, box view)
               AttachView =
-                fun (widget, treeContext, parentNode, view) ->
+                fun (widget, envContext, treeContext, parentNode, view) ->
                     treeContext.Logger.Debug("Attaching view for {0}", typeof<'T>.Name)
 
                     let view = unbox<'T> view
@@ -54,7 +54,7 @@ module Widgets =
                         | ValueNone -> None
                         | ValueSome node -> Some node
 
-                    let node = new ViewNode(parentNode, treeContext, weakReference)
+                    let node = new ViewNode(parentNode, envContext, treeContext, weakReference)
 
                     ViewNode.set node view
 
@@ -73,16 +73,16 @@ module WidgetHelpers =
     let inline compileSeq (items: seq<WidgetBuilder<'msg, 'marker>>) =
         items |> Seq.map(fun item -> item.Compile()) |> Seq.toArray
 
-    let inline buildWidgets<'msg, 'marker> (key: WidgetKey) (attrs: WidgetAttribute[]) =
-        WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), ValueSome attrs, ValueNone))
+    let inline buildWidgets<'msg, 'marker when 'msg: equality> (key: WidgetKey) (attrs: WidgetAttribute[]) =
+        WidgetBuilder<'msg, 'marker>(key, struct (StackList.empty(), attrs, [||], [||]))
 
-    let inline buildAttributeCollection<'msg, 'marker, 'item>
+    let inline buildAttributeCollection<'msg, 'marker, 'item when 'msg: equality>
         (collectionAttributeDefinition: WidgetCollectionAttributeDefinition)
         (widget: WidgetBuilder<'msg, 'marker>)
         =
         AttributeCollectionBuilder<'msg, 'marker, 'item>(widget, collectionAttributeDefinition)
 
-    let buildItems<'msg, 'marker, 'itemData, 'itemMarker>
+    let buildItems<'msg, 'marker, 'itemData, 'itemMarker when 'msg: equality>
         key
         (attrDef: SimpleScalarAttributeDefinition<WidgetItems>)
         (items: seq<'itemData>)
@@ -98,7 +98,7 @@ module WidgetHelpers =
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))
 
-    let buildGroupItems<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'groupData :> seq<'itemData>>
+    let buildGroupItems<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'msg: equality and 'groupData :> seq<'itemData>>
         key
         (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems>)
         (items: seq<'groupData>)
@@ -114,7 +114,7 @@ module WidgetHelpers =
 
         WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))
 
-    let buildGroupItemsNoFooter<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'groupData :> seq<'itemData>>
+    let buildGroupItemsNoFooter<'msg, 'marker, 'groupData, 'itemData, 'groupMarker, 'itemMarker when 'msg: equality and 'groupData :> seq<'itemData>>
         key
         (attrDef: SimpleScalarAttributeDefinition<GroupedWidgetItems>)
         (items: seq<'groupData>)


### PR DESCRIPTION
## Summary

Updates `Fabulous.MauiControls` to be compatible with the Fabulous API changes introduced between `3.0.0-pre2` (previous pinned version) and `3.0.0-pre23` (current NuGet release).

## Changes

### Core API updates
- `ViewNode` constructor now takes `envContext` as 2nd parameter
- `WidgetDefinition.CreateView`/`AttachView` signatures include `envContext` parameter
- `AttributesBundle` changed from 3-tuple with voptions to 4-tuple with plain arrays
- `Widget.ScalarAttributes`/`WidgetCollectionAttributes` are now plain arrays (not voptions)

### Renamed/moved APIs
- `Attributes.defineEvent`/`defineEventNoArg` → `Attributes.Mvu.defineEvent`/`defineEventNoArg`
- `Attributes.Mvu.defineEventNoArgNoDispatch` → `Attributes.Component.defineEventNoArg`
- `View.Component()` now requires a key string; `Context.Mvu()` replaces `Mvu.State`

### Type constraint fixes
- `WidgetBuilder` requires `'msg: equality` constraint throughout
- `ComponentBuilder` now takes 2 type params; `MvuComponentBuilder`/`SingleChildBuilder` removed

### Package version
- Bumped `Fabulous` package reference from `3.0.0-pre2` to `3.0.0-pre23`

## Build
Builds successfully with `UseLocalProjectReference=true` against the current Fabulous HEAD.